### PR TITLE
Fix company redeem

### DIFF
--- a/lib/safira_web/controllers/redeem_controller.ex
+++ b/lib/safira_web/controllers/redeem_controller.ex
@@ -12,31 +12,39 @@ defmodule SafiraWeb.RedeemController do
     user = get_user(conn)
     cond do
         is_company(conn) ->
-            redeem_params = Map.put(redeem_params, "badge_id", user.company.badge_id)
-            with {:ok, %Redeem{} = _redeem} <- Contest.create_redeem(redeem_params) do
-                  conn
-                  |> put_status(:created)
-                  |> json(%{redeem: "Badge redeem successfully"})
-            end
+            company_aux(conn,redeem_params,user)
         is_manager(conn) ->
-            case Map.fetch(redeem_params, "badge_id") do
-              {:ok, id} ->
-                Contest.get_badge!(id)
-                redeem_params = Map.put(redeem_params, "manager_id", user.manager.id)
-                with {:ok, %Redeem{} = _redeem} <- Contest.create_redeem(redeem_params) do
-                  conn
-                  |> put_status(:created)
-                  |> json(%{redeem: "Badge redeem successfully"})
-                end
-              _ ->
-                {:error, :not_found}
-            end
+            manager_aux(conn,redeem_params,user)
         true ->
             conn
             |> put_status(:unauthorized)
             |> json(%{error: "Cannot access resource"})
             |> halt()
     end
+  end
+
+  defp company_aux(conn, redeem_params, user) do
+      redeem_params = Map.put(redeem_params, "badge_id", user.company.badge_id)
+      with {:ok, %Redeem{} = _redeem} <- Contest.create_redeem(redeem_params) do
+            conn
+            |> put_status(:created)
+            |> json(%{redeem: "Badge redeem successfully"})
+      end
+  end
+
+  defp manager_aux(conn, redeem_params, user)do
+      case Map.fetch(redeem_params, "badge_id") do
+        {:ok, id} ->
+          Contest.get_badge!(id)
+          redeem_params = Map.put(redeem_params, "manager_id", user.manager.id)
+          with {:ok, %Redeem{} = _redeem} <- Contest.create_redeem(redeem_params) do
+            conn
+            |> put_status(:created)
+            |> json(%{redeem: "Badge redeem successfully"})
+          end
+        _ ->
+          {:error, :not_found}
+      end
   end
 
   defp is_company(conn) do

--- a/lib/safira_web/controllers/redeem_controller.ex
+++ b/lib/safira_web/controllers/redeem_controller.ex
@@ -4,26 +4,60 @@ defmodule SafiraWeb.RedeemController do
   alias Safira.Contest
   alias Safira.Contest.Redeem
   alias Safira.Accounts
+  alias Safira.Accounts.User
 
   action_fallback SafiraWeb.FallbackController
 
-  plug Safira.Authorize, :manager
-
   def create(conn, %{"redeem" => redeem_params}) do
-    user = Guardian.Plug.current_resource(conn)
-    |> Map.get(:id)
-    |> Accounts.get_user_preload!
-    case Map.fetch(redeem_params, "badge_id") do
-      {:ok, id} ->
-        Contest.get_badge!(id)
-        redeem_params = Map.put(redeem_params, "manager_id", user.manager.id)
-        with {:ok, %Redeem{} = _redeem} <- Contest.create_redeem(redeem_params) do
-          conn
-          |> put_status(:created)
-          |> json(%{redeem: "Badge redeem successfully"})
-        end
-      _ ->
-        {:error, :not_found}
+    user = get_user(conn)
+    cond do
+        is_company(conn) ->
+            redeem_params = Map.put(redeem_params, "badge_id", user.company.badge_id)
+            with {:ok, %Redeem{} = _redeem} <- Contest.create_redeem(redeem_params) do
+                  conn
+                  |> put_status(:created)
+                  |> json(%{redeem: "Badge redeem successfully"})
+            end
+        is_manager(conn) ->
+            case Map.fetch(redeem_params, "badge_id") do
+              {:ok, id} ->
+                Contest.get_badge!(id)
+                redeem_params = Map.put(redeem_params, "manager_id", user.manager.id)
+                with {:ok, %Redeem{} = _redeem} <- Contest.create_redeem(redeem_params) do
+                  conn
+                  |> put_status(:created)
+                  |> json(%{redeem: "Badge redeem successfully"})
+                end
+              _ ->
+                {:error, :not_found}
+            end
+        true ->
+            conn
+            |> put_status(:unauthorized)
+            |> json(%{error: "Cannot access resource"})
+            |> halt()
+    end
+  end
+
+  defp is_company(conn) do
+    get_user(conn)
+    |> Map.fetch!(:company)
+    |> is_nil
+    |> Kernel.not
+  end
+
+  defp is_manager(conn) do
+    get_user(conn)
+    |> Map.fetch!(:manager)
+    |> is_nil
+    |> Kernel.not
+  end
+
+  defp get_user(conn) do
+    with  %User{} = user <- Guardian.Plug.current_resource(conn) do
+      user
+      |> Map.fetch!(:id)
+      |> Accounts.get_user_preload!()
     end
   end
 end


### PR DESCRIPTION
Remove the specification of the company behaviour in the show
attendee, avoiding a GET from changing the attendee state.

Remove the plug Authorize in redeem_controller because there are 3
conditions in the create method where it is checked if the connection
belongs to a company or a manager, otherwise the connection is not
authorized and the redeem is not created. In this case the plug
is not needed.

Resolves: #93