### PR TITLE
Implement discord association

### DIFF
--- a/lib/mix/tasks/gen.attendees.ex
+++ b/lib/mix/tasks/gen.attendees.ex
@@ -16,9 +16,9 @@ defmodule Mix.Tasks.Gen.Attendees do
     Mix.Task.run "app.start"
 
     Enum.each 1..n, fn(_n) ->
-      Safira.Repo.insert!(%Safira.Accounts.Attendee{})
-      |> Map.get(:id)
-      |> IO.puts
+      created_attendee = Safira.Repo.insert!(%Safira.Accounts.Attendee{})
+      IO.puts("Id: #{Map.get(created_attendee, :id)}")
+      IO.puts("Association_code: #{Map.get(created_attendee, :association_code)}")
     end
   end
 end

--- a/lib/mix/tasks/gen.attendees.ex
+++ b/lib/mix/tasks/gen.attendees.ex
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.Gen.Attendees do
     Enum.each 1..n, fn(_n) ->
       created_attendee = Safira.Repo.insert!(%Safira.Accounts.Attendee{})
       IO.puts("Id: #{Map.get(created_attendee, :id)}")
-      IO.puts("Association_code: #{Map.get(created_attendee, :association_code)}")
+      IO.puts("Association_code: #{Map.get(created_attendee, :discord_association_code)}")
     end
   end
 end

--- a/lib/mix/tasks/gen.attendees.ex
+++ b/lib/mix/tasks/gen.attendees.ex
@@ -4,21 +4,23 @@ defmodule Mix.Tasks.Gen.Attendees do
   def run(args) do
     cond do
       length(args) == 0 ->
-        Mix.shell.info "Needs to receive a number greater than 0."
-      args |> List.first |> String.to_integer <= 0 ->
-        Mix.shell.info "Needs to receive a number greater than 0."
+        Mix.shell().info("Needs to receive a number greater than 0.")
+
+      args |> List.first() |> String.to_integer() <= 0 ->
+        Mix.shell().info("Needs to receive a number greater than 0.")
+
       true ->
-        args |> List.first |> String.to_integer |> create
+        args |> List.first() |> String.to_integer() |> create
     end
   end
 
   defp create(n) do
-    Mix.Task.run "app.start"
+    Mix.Task.run("app.start")
 
-    Enum.each 1..n, fn(_n) ->
+    Enum.each(1..n, fn _n ->
       created_attendee = Safira.Repo.insert!(%Safira.Accounts.Attendee{})
       IO.puts("Id: #{Map.get(created_attendee, :id)}")
       IO.puts("Association_code: #{Map.get(created_attendee, :discord_association_code)}")
-    end
+    end)
   end
 end

--- a/lib/safira/accounts/accounts.ex
+++ b/lib/safira/accounts/accounts.ex
@@ -98,8 +98,14 @@ defmodule Safira.Accounts do
     try do
       Repo.get_by(Attendee, discord_association_code: discord_association_code)
     rescue
-      _e in Ecto.Query.CastError -> nil
+      _e in Ecto.Query.CastError -> nil # since this code is sent by an user and it should be an UUID
     end
+  end
+
+  def get_attendee_by_discord_id(discord_id) do
+      Repo.get_by(Attendee, discord_id: discord_id)
+      |> Repo.preload(:badges)
+      |> Repo.preload(:user)
   end
 
   def create_attendee(attrs \\ %{}) do

--- a/lib/safira/accounts/accounts.ex
+++ b/lib/safira/accounts/accounts.ex
@@ -94,6 +94,14 @@ defmodule Safira.Accounts do
     |> Repo.preload(:badges)
   end
 
+  def get_attendee_by_discord_association_code(discord_association_code) do
+    try do
+      Repo.get_by(Attendee, discord_association_code: discord_association_code)
+    rescue
+      _e in Ecto.Query.CastError -> nil
+    end
+  end
+
   def create_attendee(attrs \\ %{}) do
     %Attendee{}
     |> Attendee.changeset(attrs)
@@ -106,13 +114,26 @@ defmodule Safira.Accounts do
     |> Repo.update()
   end
 
+  def update_attendee_association(%Attendee{} = attendee, attrs) do
+    attendee
+    |> Attendee.update_changeset_discord_association(attrs)
+    |> Repo.update()
+  end
+
   def update_attendee_sign_up(%Attendee{} = attendee, attrs) do
     attendee
     |> Attendee.update_changeset_sign_up(attrs)
     |> Repo.update()
   end
 
+
   def volunteer_update_attendee(%Attendee{} = attendee, attrs) do
+    attendee
+    |> Attendee.volunteer_changeset(attrs)
+    |> Repo.update()
+  end
+
+  def discord_association_update_attendee(%Attendee{} = attendee, attrs) do
     attendee
     |> Attendee.volunteer_changeset(attrs)
     |> Repo.update()

--- a/lib/safira/accounts/accounts.ex
+++ b/lib/safira/accounts/accounts.ex
@@ -138,11 +138,6 @@ defmodule Safira.Accounts do
     |> Repo.update()
   end
 
-  def discord_association_update_attendee(%Attendee{} = attendee, attrs) do
-    attendee
-    |> Attendee.volunteer_changeset(attrs)
-    |> Repo.update()
-  end
 
   def delete_attendee(%Attendee{} = attendee) do
     Repo.delete(attendee)

--- a/lib/safira/accounts/accounts.ex
+++ b/lib/safira/accounts/accounts.ex
@@ -132,7 +132,6 @@ defmodule Safira.Accounts do
     |> Repo.update()
   end
 
-
   def volunteer_update_attendee(%Attendee{} = attendee, attrs) do
     attendee
     |> Attendee.volunteer_changeset(attrs)

--- a/lib/safira/accounts/accounts.ex
+++ b/lib/safira/accounts/accounts.ex
@@ -95,10 +95,9 @@ defmodule Safira.Accounts do
   end
 
   def get_attendee_by_discord_association_code(discord_association_code) do
-    try do
-      Repo.get_by(Attendee, discord_association_code: discord_association_code)
-    rescue
-      _e in Ecto.Query.CastError -> nil # since this code is sent by an user and it should be an UUID
+    case Ecto.UUID.cast(discord_association_code) do
+      {:ok, casted_code} -> Repo.get_by(Attendee, discord_association_code: casted_code)
+      _ -> nil
     end
   end
 

--- a/lib/safira/accounts/attendee.ex
+++ b/lib/safira/accounts/attendee.ex
@@ -15,6 +15,8 @@ defmodule Safira.Accounts.Attendee do
     field :volunteer, :boolean, default: false
     field :avatar, Safira.Avatar.Type
     field :name, :string
+    field :association_code, Ecto.UUID, autogenerate: true
+    field :discord_id, :string
 
     belongs_to :user, User
     many_to_many :badges, Badge, join_through: Redeem

--- a/lib/safira/accounts/attendee.ex
+++ b/lib/safira/accounts/attendee.ex
@@ -59,6 +59,11 @@ defmodule Safira.Accounts.Attendee do
     |> unique_constraint(:nickname)
   end
 
+  def update_changeset_discord_association(attendee, attrs) do
+    attendee
+    |> cast(attrs, [:discord_id])
+  end
+
   def volunteer_changeset(attendee, attrs) do
     attendee
     |> cast(attrs, [:volunteer])

--- a/lib/safira/accounts/attendee.ex
+++ b/lib/safira/accounts/attendee.ex
@@ -15,7 +15,7 @@ defmodule Safira.Accounts.Attendee do
     field :volunteer, :boolean, default: false
     field :avatar, Safira.Avatar.Type
     field :name, :string
-    field :association_code, Ecto.UUID, autogenerate: true
+    field :discord_association_code, Ecto.UUID, autogenerate: true
     field :discord_id, :string
 
     belongs_to :user, User

--- a/lib/safira_web/controllers/auth_controller.ex
+++ b/lib/safira_web/controllers/auth_controller.ex
@@ -4,7 +4,6 @@ defmodule SafiraWeb.AuthController do
   alias Safira.Auth
   alias Safira.Accounts
   alias Safira.Guardian
-  require IEx
 
   action_fallback SafiraWeb.FallbackController
 

--- a/lib/safira_web/controllers/auth_controller.ex
+++ b/lib/safira_web/controllers/auth_controller.ex
@@ -13,7 +13,7 @@ defmodule SafiraWeb.AuthController do
          {:ok, token, _claims} <- Guardian.encode_and_sign(multi.user) do
       conn
       |> render("signup_response.json", %{jwt: token,
-       association_code: multi.attendee.association_code})
+      discord_association_code: multi.attendee.discord_association_code})
     end
   end
 

--- a/lib/safira_web/controllers/auth_controller.ex
+++ b/lib/safira_web/controllers/auth_controller.ex
@@ -4,6 +4,7 @@ defmodule SafiraWeb.AuthController do
   alias Safira.Auth
   alias Safira.Accounts
   alias Safira.Guardian
+  require IEx
 
   action_fallback SafiraWeb.FallbackController
 
@@ -11,7 +12,8 @@ defmodule SafiraWeb.AuthController do
     with {:ok, multi} <- Auth.create_user_uuid(user_params),
          {:ok, token, _claims} <- Guardian.encode_and_sign(multi.user) do
       conn
-      |> render("jwt.json", jwt: token)
+      |> render("signup_response.json", %{jwt: token,
+       association_code: multi.attendee.association_code})
     end
   end
 
@@ -22,15 +24,15 @@ defmodule SafiraWeb.AuthController do
       cond do
         not is_nil user_preload.attendee ->
           user
-          |> Map.put(:id, user_preload.id) 
+          |> Map.put(:id, user_preload.id)
           |> Map.put(:type, "attendee")
         not is_nil user_preload.company ->
           user
-          |> Map.put(:id, user_preload.id) 
+          |> Map.put(:id, user_preload.id)
           |> Map.put(:type, "company")
         not is_nil user_preload.manager ->
           user
-          |> Map.put(:id, user_preload.id) 
+          |> Map.put(:id, user_preload.id)
           |> Map.put(:type, "manager")
       end
     render(conn, "user.json", user: user)
@@ -62,7 +64,7 @@ defmodule SafiraWeb.AuthController do
     attendee = Accounts.get_attendee!(id)
     case is_nil attendee do
       true ->
-        {:error, :not_found}      
+        {:error, :not_found}
       false ->
         render(conn, "is_registered.json", is_registered: not is_nil attendee.user_id)
     end

--- a/lib/safira_web/controllers/auth_controller.ex
+++ b/lib/safira_web/controllers/auth_controller.ex
@@ -8,11 +8,12 @@ defmodule SafiraWeb.AuthController do
   action_fallback SafiraWeb.FallbackController
 
   def sign_up(conn, %{"user" => user_params}) do
-    with {:ok, multi} <- Auth.create_user_uuid(user_params),
-         {:ok, token, _claims} <- Guardian.encode_and_sign(multi.user) do
+    with {:ok, %{user: user,
+          attendee: %{discord_association_code: code}}} <- Auth.create_user_uuid(user_params),
+         {:ok, token, _claims} <- Guardian.encode_and_sign(user) do
       conn
       |> render("signup_response.json", %{jwt: token,
-      discord_association_code: multi.attendee.discord_association_code})
+      discord_association_code: code})
     end
   end
 

--- a/lib/safira_web/controllers/discord_association_controller.ex
+++ b/lib/safira_web/controllers/discord_association_controller.ex
@@ -25,14 +25,14 @@ defmodule SafiraWeb.DiscordAssociationController do
     cond do
       not is_nil attendee ->
          # no need for checking if discord_id is valid
-         # since the the user's discord_id is attained by the bot through the discord API
+         # since the the user's discord_id is obtained by the bot through the discord API
          Accounts.update_attendee_association(attendee, %{discord_id: discord_id})
          conn
          |> put_status(:created)
          |> json(%{association: "Attendee discord_id successfully associated"})
       true ->
         conn
-        |> put_status(:error)
+        |> put_status(:not_found)
         |> json(%{error: "Attendee not found"})
     end
   end

--- a/lib/safira_web/controllers/discord_association_controller.ex
+++ b/lib/safira_web/controllers/discord_association_controller.ex
@@ -1,0 +1,39 @@
+defmodule SafiraWeb.DiscordAssociationController do
+  use SafiraWeb, :controller
+
+  alias Safira.Accounts
+  alias Safira.Accounts.Attendee
+
+  action_fallback SafiraWeb.FallbackController
+
+  #association_params= %{"discord_association_code" => discord_association_code, "discord_id" => discord_id}
+  def create(conn,association_params) do
+    cond do
+      Accounts.is_manager(conn) ->
+        association_aux(conn,association_params)
+      true ->
+        conn
+        |> put_status(:unauthorized)
+        |> json(%{error: "Cannot access resource"})
+        |> halt()
+    end
+  end
+
+  defp association_aux(conn, %{"discord_association_code" => discord_association_code,
+                     "discord_id" => discord_id}) do
+    attendee = Accounts.get_attendee_by_discord_association_code(discord_association_code)
+    cond do
+      not is_nil attendee ->
+         # no need for checking if discord_id is valid
+         # since the the user's discord_id is attained by the bot through the discord API
+         Accounts.update_attendee_association(attendee, %{discord_id: discord_id})
+         conn
+         |> put_status(:created)
+         |> json(%{association: "Attendee discord_id successfully associated"})
+      true ->
+        conn
+        |> put_status(:error)
+        |> json(%{error: "Attendee not found"})
+    end
+  end
+end

--- a/lib/safira_web/controllers/discord_association_controller.ex
+++ b/lib/safira_web/controllers/discord_association_controller.ex
@@ -6,11 +6,12 @@ defmodule SafiraWeb.DiscordAssociationController do
 
   action_fallback SafiraWeb.FallbackController
 
-  #association_params= %{"discord_association_code" => discord_association_code, "discord_id" => discord_id}
-  def create(conn,association_params) do
+  # association_params= %{"discord_association_code" => discord_association_code, "discord_id" => discord_id}
+  def create(conn, association_params) do
     cond do
       Accounts.is_manager(conn) ->
-        association_aux(conn,association_params)
+        association_aux(conn, association_params)
+
       true ->
         conn
         |> put_status(:unauthorized)
@@ -19,17 +20,22 @@ defmodule SafiraWeb.DiscordAssociationController do
     end
   end
 
-  defp association_aux(conn, %{"discord_association_code" => discord_association_code,
-                     "discord_id" => discord_id}) do
+  defp association_aux(conn, %{
+         "discord_association_code" => discord_association_code,
+         "discord_id" => discord_id
+       }) do
     attendee = Accounts.get_attendee_by_discord_association_code(discord_association_code)
+
     cond do
-      not is_nil attendee ->
-         # no need for checking if discord_id is valid
-         # since the the user's discord_id is obtained by the bot through the discord API
-         Accounts.update_attendee_association(attendee, %{discord_id: discord_id})
-         conn
-         |> put_status(:created)
-         |> json(%{association: "Attendee discord_id successfully associated"})
+      not is_nil(attendee) ->
+        # no need for checking if discord_id is valid
+        # since the the user's discord_id is obtained by the bot through the discord API
+        Accounts.update_attendee_association(attendee, %{discord_id: discord_id})
+
+        conn
+        |> put_status(:created)
+        |> json(%{association: "Attendee discord_id successfully associated"})
+
       true ->
         conn
         |> put_status(:not_found)

--- a/lib/safira_web/router.ex
+++ b/lib/safira_web/router.ex
@@ -52,6 +52,7 @@ defmodule SafiraWeb.Router do
       get "/attendee", AuthController, :attendee
       get "/company", AuthController, :company
       get "/leaderboard", LeaderboardController, :index
+      post "/association", DiscordAssociationController, :create
 
       resources "/badges", BadgeController, only: [:index, :show]
       resources "/attendees", AttendeeController, except: [:create]

--- a/lib/safira_web/views/auth_view.ex
+++ b/lib/safira_web/views/auth_view.ex
@@ -34,7 +34,8 @@ defmodule SafiraWeb.AuthView do
     }
   end
 
-  def render("jwt.json", %{jwt: jwt}) do
-    %{jwt: jwt}
+  def render("signup_response.json", %{jwt: jwt, association_code: association_code}) do
+    %{jwt: jwt,
+      association_code: association_code}
   end
 end

--- a/lib/safira_web/views/auth_view.ex
+++ b/lib/safira_web/views/auth_view.ex
@@ -34,8 +34,8 @@ defmodule SafiraWeb.AuthView do
     }
   end
 
-  def render("signup_response.json", %{jwt: jwt, association_code: association_code}) do
+  def render("signup_response.json", %{jwt: jwt, discord_association_code: discord_association_code}) do
     %{jwt: jwt,
-      association_code: association_code}
+    discord_association_code: discord_association_code}
   end
 end

--- a/lib/safira_web/views/auth_view.ex
+++ b/lib/safira_web/views/auth_view.ex
@@ -34,6 +34,11 @@ defmodule SafiraWeb.AuthView do
     }
   end
 
+  def render("jwt.json", %{jwt: jwt}) do
+    %{jwt: jwt}
+  end
+
+
   def render("signup_response.json", %{jwt: jwt, discord_association_code: discord_association_code}) do
     %{jwt: jwt,
     discord_association_code: discord_association_code}

--- a/priv/repo/migrations/20210124200209_add_association_code_and_discord_id.exs
+++ b/priv/repo/migrations/20210124200209_add_association_code_and_discord_id.exs
@@ -1,0 +1,12 @@
+defmodule Safira.Repo.Migrations.AddAssociationCodeAndDiscordId do
+  use Ecto.Migration
+
+  def change do
+    alter table(:attendees) do
+      add :association_code, :uuid, null: false
+      add :discord_id, :string
+    end
+
+      create unique_index(:attendees, [:discord_id])
+  end
+end

--- a/priv/repo/migrations/20210124200209_add_discord_association_code_and_discord_id.exs
+++ b/priv/repo/migrations/20210124200209_add_discord_association_code_and_discord_id.exs
@@ -7,6 +7,7 @@ defmodule Safira.Repo.Migrations.AddDiscordAssociationCodeAndDiscordId do
       add :discord_id, :string
     end
 
+      create unique_index(:attendees, [:discord_association_code])
       create unique_index(:attendees, [:discord_id])
   end
 end

--- a/priv/repo/migrations/20210124200209_add_discord_association_code_and_discord_id.exs
+++ b/priv/repo/migrations/20210124200209_add_discord_association_code_and_discord_id.exs
@@ -1,9 +1,9 @@
-defmodule Safira.Repo.Migrations.AddAssociationCodeAndDiscordId do
+defmodule Safira.Repo.Migrations.AddDiscordAssociationCodeAndDiscordId do
   use Ecto.Migration
 
   def change do
     alter table(:attendees) do
-      add :association_code, :uuid, null: false
+      add :discord_association_code, :uuid, null: false
       add :discord_id, :string
     end
 

--- a/priv/repo/migrations/20210124200209_add_discord_association_code_and_discord_id.exs
+++ b/priv/repo/migrations/20210124200209_add_discord_association_code_and_discord_id.exs
@@ -7,7 +7,7 @@ defmodule Safira.Repo.Migrations.AddDiscordAssociationCodeAndDiscordId do
       add :discord_id, :string
     end
 
-      create unique_index(:attendees, [:discord_association_code])
-      create unique_index(:attendees, [:discord_id])
+    create unique_index(:attendees, [:discord_association_code])
+    create unique_index(:attendees, [:discord_id])
   end
 end


### PR DESCRIPTION
- Add discord_association_code and discord_id fields to attendee
- Change gen.attendees task to also display the created discord_association_code
- Change signup to now return an association_code alongside the jwt, for the attendee to give as input to the discord bot
- Create DiscordAssociationController, used to associate an discord_id with an attendee given an discord_association_code 
- Create get_by_discord_id method for future use by other controllers which interact with the discord bot

Solves #137 

Some questions regarding code best practices will be left as comment