### PR TITLE
Daily Leaderboard

### DIFF
--- a/lib/safira/contest/contest.ex
+++ b/lib/safira/contest/contest.ex
@@ -154,13 +154,13 @@ defmodule Safira.Contest do
   end
 
   def list_daily_leaderboard(date) do
-    query = from a in Safira.Accounts.Attendee,
-      join: r in Redeem, on: a.id == r.attendee_id,
-      join: b in Badge, on: r.badge_id == b.id,
-      where: not(is_nil a.user_id) and fragment("?::date", r.inserted_at) == ^date and b.type != ^0,
-      preload: [badges: b]
-
-    Repo.all(query)
+    Repo.all(
+      from a in Safira.Accounts.Attendee,
+        join: r in Redeem, on: a.id == r.attendee_id,
+        join: b in Badge, on: r.badge_id == b.id,
+        where: not(is_nil a.user_id) and fragment("?::date", r.inserted_at) == ^date and b.type != ^0,
+        preload: [badges: b]
+    )
     |> Enum.map(fn a -> Map.put(a, :badge_count, length(a.badges)) end)
     |> Enum.sort(&(&1.badge_count >= &2.badge_count))
   end

--- a/lib/safira/contest/contest.ex
+++ b/lib/safira/contest/contest.ex
@@ -11,18 +11,18 @@ defmodule Safira.Contest do
   end
 
   def list_secret do
-    Repo.all(from r in Redeem, 
-      join: b in assoc(r, :badge), 
-      join: a in assoc(r, :attendee), 
-      where: b.type == ^1 and not(a.volunteer) and not(is_nil(a.nickname)), 
-      preload: [badge: b, attendee: a], 
+    Repo.all(from r in Redeem,
+      join: b in assoc(r, :badge),
+      join: a in assoc(r, :attendee),
+      where: b.type == ^1 and not(a.volunteer) and not(is_nil(a.nickname)),
+      preload: [badge: b, attendee: a],
       distinct: :badge_id)
-    |> Enum.map(fn x -> x.badge end) 
+    |> Enum.map(fn x -> x.badge end)
 
   end
-  
+
   def list_normals do
-    Repo.all(from b in  Badge, 
+    Repo.all(from b in  Badge,
       where: b.type != ^1 and b.type != ^0)
   end
 
@@ -110,17 +110,17 @@ defmodule Safira.Contest do
     Repo.all(Redeem)
   end
 
-  def list_redeems_stats do 
-    Repo.all(from r in Redeem, 
-      join: b in assoc(r, :badge), 
-      join: a in assoc(r, :attendee), 
-      where: b.type == ^1 and not(a.volunteer) and not(is_nil(a.nickname)), 
+  def list_redeems_stats do
+    Repo.all(from r in Redeem,
+      join: b in assoc(r, :badge),
+      join: a in assoc(r, :attendee),
+      where: b.type == ^1 and not(a.volunteer) and not(is_nil(a.nickname)),
       preload: [badge: b, attendee: a])
   end
 
   def get_redeem!(id), do: Repo.get!(Redeem, id)
 
-  def get_keys_redeem(attendee_id, badge_id) do 
+  def get_keys_redeem(attendee_id, badge_id) do
     Repo.get_by(Redeem, [attendee_id: attendee_id, badge_id: badge_id])
   end
 
@@ -145,11 +145,23 @@ defmodule Safira.Contest do
   end
 
   def list_leaderboard do
-    Repo.all(from a in Safira.Accounts.Attendee, 
+    Repo.all(from a in Safira.Accounts.Attendee,
       where: not (is_nil a.user_id))
     #|> Repo.preload(:badges)
     |> Repo.preload([badges: from(b in Badge, where: b.type != ^0)])
     |> Enum.map(fn x -> Map.put(x, :badge_count, length(Enum.filter(x.badges,fn x -> x.type != 0 end))) end)
+    |> Enum.sort(&(&1.badge_count >= &2.badge_count))
+  end
+
+  def list_daily_leaderboard(date) do
+    query = from a in Safira.Accounts.Attendee,
+      join: r in Redeem, on: a.id == r.attendee_id,
+      join: b in Badge, on: r.badge_id == b.id,
+      where: not(is_nil a.user_id) and fragment("?::date", r.inserted_at) == ^date and b.type != ^0,
+      preload: [badges: b]
+
+    Repo.all(query)
+    |> Enum.map(fn a -> Map.put(a, :badge_count, length(a.badges)) end)
     |> Enum.sort(&(&1.badge_count >= &2.badge_count))
   end
 
@@ -160,7 +172,7 @@ defmodule Safira.Contest do
   end
 
   def get_winner do
-    Repo.all(from a in Safira.Accounts.Attendee, 
+    Repo.all(from a in Safira.Accounts.Attendee,
       where: not (is_nil a.user_id) and not(a.volunteer))
     |> Repo.preload([badges: from(b in Badge, where: b.type != ^0)])
     |> Enum.map(fn x -> Map.put(x, :badge_count, length(Enum.filter(x.badges,fn x -> x.type != 0 end))) end)

--- a/lib/safira_web/controllers/leaderboard_controller.ex
+++ b/lib/safira_web/controllers/leaderboard_controller.ex
@@ -9,4 +9,19 @@ defmodule SafiraWeb.LeaderboardController do
     attendees = Contest.list_leaderboard()
     render(conn, SafiraWeb.LeaderboardView, "index.json", attendees: attendees)
   end
+
+  def daily(conn, %{"date" => date_params}) do
+    case Date.from_iso8601(date_params) do
+      {:ok, result} ->
+
+        attendees = Contest.list_daily_leaderboard(result)
+        #IO.inspect(attendees)
+        render(conn, SafiraWeb.LeaderboardView, "index.json", attendees: attendees)
+
+      {:error, _error} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{error: "Date should be in {YYYY}-{MM}-{DD} format"})
+    end
+  end
 end

--- a/lib/safira_web/controllers/leaderboard_controller.ex
+++ b/lib/safira_web/controllers/leaderboard_controller.ex
@@ -13,9 +13,7 @@ defmodule SafiraWeb.LeaderboardController do
   def daily(conn, %{"date" => date_params}) do
     case Date.from_iso8601(date_params) do
       {:ok, result} ->
-
         attendees = Contest.list_daily_leaderboard(result)
-        #IO.inspect(attendees)
         render(conn, SafiraWeb.LeaderboardView, "index.json", attendees: attendees)
 
       {:error, _error} ->

--- a/lib/safira_web/router.ex
+++ b/lib/safira_web/router.ex
@@ -52,6 +52,7 @@ defmodule SafiraWeb.Router do
       get "/attendee", AuthController, :attendee
       get "/company", AuthController, :company
       get "/leaderboard", LeaderboardController, :index
+      get "/leaderboard/:date", LeaderboardController, :daily
 
       resources "/badges", BadgeController, only: [:index, :show]
       resources "/attendees", AttendeeController, except: [:create]


### PR DESCRIPTION
Add new endpoint `get "/leaderboard/:date"`, where the :date represents the day we want to consult the leaderboard. This date is in the "YYYY-MM-DD" format, so a possible request to this endpoint could be `/api/v1/leaderboard/2021-02-05`.

Resolves: #139 