### PR TITLE
Implement task to create users from csv (new)

### DIFF
--- a/lib/mix/tasks/gen.company.ex
+++ b/lib/mix/tasks/gen.company.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Gen.Company do
   use Mix.Task
   alias Safira.Accounts
 
-  @domain "enei.pt"
+  @domain "seium.org"
 
   def run(args) do
     cond do

--- a/lib/mix/tasks/gen.managers.ex
+++ b/lib/mix/tasks/gen.managers.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Gen.Managers do
   use Mix.Task
   alias Safira.Accounts
 
-  @domain "enei.pt"
+  @domain "seium.org"
 
   def run(args) do
     cond do

--- a/lib/mix/tasks/gen.user_with_badge.ex
+++ b/lib/mix/tasks/gen.user_with_badge.ex
@@ -28,8 +28,8 @@ defmodule Mix.Tasks.Gen.UserWithBadge do
     :ssl.start()
 
     case :httpc.request(:get, {to_charlist(url), []}, [], stream: '/tmp/user.csv') do
-      {:ok, _resp} -> 
-        parse_csv("/tmp/user.csv") 
+      {:ok, _resp} ->
+        parse_csv("/tmp/user.csv")
         |> create_user_give_badge
 
       {:error, resp} -> resp
@@ -50,7 +50,7 @@ defmodule Mix.Tasks.Gen.UserWithBadge do
     badge_11 = Contest.get_badge_name!("Alojamento Alberto Sampaio")
 
     Enum.map(list_user_csv, fn user_csv ->
-      multi = 
+      multi =
         Multi.new()
         |> Multi.insert(
           :user,
@@ -69,7 +69,7 @@ defmodule Mix.Tasks.Gen.UserWithBadge do
           end
         )
 
-      multi = 
+      multi =
         cond do
           user_csv.housing == "Não tem" ->
             Enum.reduce(
@@ -84,7 +84,7 @@ defmodule Mix.Tasks.Gen.UserWithBadge do
             give_badge(badge_11.id, multi)
         end
 
-      multi = 
+      multi =
         if user_csv.food == 0 do
           Enum.reduce(
             [badge_4, badge_5, badge_6, badge_7, badge_8, badge_9],
@@ -104,11 +104,10 @@ defmodule Mix.Tasks.Gen.UserWithBadge do
 
   defp send_mail(transaction) do
     case transaction do
-      {:ok, changes} -> 
+      {:ok, changes} ->
         user = Auth.reset_password_token(changes.user)
 
         Safira.Email.send_password_email(user.email, user.reset_password_token)
-        |>Safira.Mailer.deliver_now()
 
       _ -> transaction
     end

--- a/lib/mix/tasks/gen.users_from_csv.ex
+++ b/lib/mix/tasks/gen.users_from_csv.ex
@@ -21,12 +21,12 @@ defmodule Mix.Tasks.Gen.UsersFromCsv do
   defp create(path) do
     Mix.Task.run("app.start")
 
-    if File.exists?(path) do
+    try do
       path
-      |> parse_csv
-      |> create_users
-    else
-      IO.puts("File does not exist")
+        |> parse_csv
+        |> create_users
+    rescue
+      e in File.Error -> IO.inspect e
     end
   end
 
@@ -94,7 +94,6 @@ defmodule Mix.Tasks.Gen.UsersFromCsv do
         user = Auth.reset_password_token(changes.user)
 
         Safira.Email.send_password_email(user.email, user.reset_password_token)
-        |>Safira.Mailer.deliver_now()
 
       _ ->
         transaction

--- a/lib/mix/tasks/gen.users_from_csv.ex
+++ b/lib/mix/tasks/gen.users_from_csv.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Gen.UsersFromCsv do
   alias Safira.Accounts.User
   alias Safira.Accounts.Attendee
 
-  NimbleCSV.define(SeiParser, separator: ",", escape: "\"")
+  alias NimbleCSV.RFC4180, as: CSV
 
   def run(args) do
     cond do
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.Gen.UsersFromCsv do
   defp parse_csv(path) do
     path
     |> File.stream!(read_ahead: 1_000)
-    |> SeiParser.parse_stream()
+    |> CSV.parse_stream()
     |> Stream.map(fn row ->
       %{
         name: "#{Enum.at(row, 2)} #{Enum.at(row, 3)}",

--- a/lib/mix/tasks/gen.users_from_csv.ex
+++ b/lib/mix/tasks/gen.users_from_csv.ex
@@ -1,0 +1,103 @@
+defmodule Mix.Tasks.Gen.UsersFromCsv do
+  use Mix.Task
+  alias Ecto.Multi
+  alias Safira.Repo
+  alias Safira.Auth
+  alias Safira.Accounts.User
+  alias Safira.Accounts.Attendee
+
+  NimbleCSV.define(SeiParser, separator: ",", escape: "\"")
+
+  def run(args) do
+    cond do
+      Enum.empty?(args) ->
+        Mix.shell().info("Needs to receive a file URL.")
+
+      true ->
+        args |> List.first() |> create
+    end
+  end
+
+  defp create(path) do
+    Mix.Task.run("app.start")
+
+    if File.exists?(path) do
+      path
+      |> parse_csv
+      |> create_users
+    else
+      IO.puts("File does not exist")
+    end
+  end
+
+  defp parse_csv(path) do
+    path
+    |> File.stream!(read_ahead: 1_000)
+    |> SeiParser.parse_stream()
+    |> Stream.map(fn row ->
+      %{
+        name: "#{Enum.at(row, 2)} #{Enum.at(row, 3)}",
+        email: Enum.at(row, 4)
+      }
+    end)
+  end
+
+  defp create_users(user_csv_stream) do
+    Enum.map(user_csv_stream, fn user_csv_entry ->
+      Multi.new()
+      |> Multi.insert(
+        :user,
+        create_user_aux(user_csv_entry)
+      )
+      |> Multi.insert(
+        :attendee,
+        fn %{user: user} ->
+          create_attendee_aux(user, user_csv_entry)
+        end
+      )
+      |> Repo.transaction()
+      |> send_mail()
+    end)
+  end
+
+  defp create_user_aux(user) do
+    password = random_string(8)
+
+    user = %{
+      "email" => user.email,
+      "password" => password,
+      "password_confirmation" => password
+    }
+
+    User.changeset(%User{}, user)
+  end
+
+  defp create_attendee_aux(user, user_csv_entry) do
+    Attendee.only_user_changeset(
+      %Attendee{},
+      %{
+        user_id: user.id,
+        name: user_csv_entry.name
+      }
+    )
+  end
+
+  defp random_string(length) do
+    :crypto.strong_rand_bytes(length)
+    |> Base.url_encode64()
+    |> binary_part(0, length)
+  end
+
+  defp send_mail(transaction) do
+    case transaction do
+      {:ok, changes} ->
+        user = Auth.reset_password_token(changes.user)
+
+        Safira.Email.send_password_email(user.email, user.reset_password_token)
+        |>Safira.Mailer.deliver_now()
+
+      _ ->
+        transaction
+    end
+  end
+end

--- a/lib/safira/email.ex
+++ b/lib/safira/email.ex
@@ -1,7 +1,6 @@
 defmodule Safira.Email do
   #use Bamboo.Phoenix, view: Safira.FeedbackView
   import Bamboo.Email
-  import Bamboo.Phoenix
 
   def send_reset_email(to_email, token) do
     new_email()

--- a/lib/safira/email.ex
+++ b/lib/safira/email.ex
@@ -9,6 +9,7 @@ defmodule Safira.Email do
     |> from(System.get_env("FROM_EMAIL"))
     |> subject("Reset Password Instructions")
     |> text_body("Please visit #{System.get_env("FRONTEND_URL")}/reset?token=#{token} to reset your password")
+    |> Safira.Mailer.deliver_now()
   end
 
   def send_password_email(to_email, token) do
@@ -17,5 +18,6 @@ defmodule Safira.Email do
     |> from(System.get_env("FROM_EMAIL"))
     |> subject("Finish account registration")
     |> text_body("Please visit #{System.get_env("FRONTEND_URL")}/reset?token=#{token} to finish your account registration")
+    |> Safira.Mailer.deliver_now()
   end
 end

--- a/lib/safira_web/controllers/password_controller.ex
+++ b/lib/safira_web/controllers/password_controller.ex
@@ -24,7 +24,6 @@ defmodule SafiraWeb.PasswordController do
         user = Auth.reset_password_token(user)
         # send password token to pw_params["email"]
         Safira.Email.send_reset_email(email, user.reset_password_token)
-        |> Safira.Mailer.deliver_now()
 
         conn
         |> put_status(:created)


### PR DESCRIPTION
 - Create get.user_from_csv task, very simillar to gen.user_with_badges, but does not attribute the food/housing badges, reads the .csv locally instead of from a remote server, also renames references from enei to sei.
 - Changes the manager's email domain from enei.pt to seium.org
 - The mechanic associated with sending the emails is now inside of the Safira.Email module
 - Change the CSV parser to RFC4180
