### PR TITLE
Remove System.get_env from Controller

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -18,8 +18,7 @@ config :safira, SafiraWeb.Endpoint,
   url: [host: "localhost"],
   secret_key_base: "3KpMz5Dsmzm2+40c8Urp8UC0N95fFWvsHudtIUHjTv2yGsikjN3wIHPNPi3e+4xi",
   render_errors: [view: SafiraWeb.ErrorView, accepts: ~w(json)],
-  pubsub: [name: Safira.PubSub,
-           adapter: Phoenix.PubSub.PG2]
+  pubsub: [name: Safira.PubSub, adapter: Phoenix.PubSub.PG2]
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,7 +8,10 @@
 use Mix.Config
 
 config :safira,
-  ecto_repos: [Safira.Repo]
+  ecto_repos: [Safira.Repo],
+  company_code: System.get_env("COMPANY_CODE"),
+  speaker_code: System.get_env("SPEAKER_CODE"),
+  staff_code: System.get_env("STAFF_CODE")
 
 # Configures the endpoint
 config :safira, SafiraWeb.Endpoint,

--- a/lib/safira_web/controllers/discord_association_controller.ex
+++ b/lib/safira_web/controllers/discord_association_controller.ex
@@ -56,7 +56,6 @@ defmodule SafiraWeb.DiscordAssociationController do
            "discord_id" => _discord_id
          }
        ) do
-    # System.get_env can't be used in a match clause
     company_code = Application.fetch_env!(:safira, :company_code)
     staff_code = Application.fetch_env!(:safira, :staff_code)
     speaker_code = Application.fetch_env!(:safira, :speaker_code)

--- a/lib/safira_web/controllers/discord_association_controller.ex
+++ b/lib/safira_web/controllers/discord_association_controller.ex
@@ -57,9 +57,9 @@ defmodule SafiraWeb.DiscordAssociationController do
          }
        ) do
     # System.get_env can't be used in a match clause
-    company_code = System.get_env("COMPANY_CODE")
-    staff_code = System.get_env("STAFF_CODE")
-    speaker_code = System.get_env("SPEAKER_CODE")
+    company_code = Application.fetch_env!(:safira, :company_code)
+    staff_code = Application.fetch_env!(:safira, :staff_code)
+    speaker_code = Application.fetch_env!(:safira, :speaker_code)
 
     case discord_association_code do
       ^company_code -> notify_succesful_association(conn, "empresa")


### PR DESCRIPTION
`System.get_env` gets from the system environment, while `Application.fetch_env` gets from the applications environment.
The system-environment is not part of the application environment, since it is not any part of elixir or the BEAM. So, it should not be used in the application code. Only during the application initialization. Once the application is initialized, the environment should always be queried by `Application.fetch_env`.