### PR TITLE
Roulette - Context and Schemas

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -13,7 +13,10 @@ config :logger, level: :warn
 config :safira, Safira.Repo,
   adapter: Ecto.Adapters.Postgres,
   database: "safira_test",
-  hostname: "localhost",
+  username: System.get_env("DB_USERNAME", "safira"),
+  password: System.get_env("DB_PASSWORD", "secret"),
+  port: System.get_env("DB_PORT", "5432"),
+  hostname: System.get_env("DB_HOST", "localhost"),
   pool: Ecto.Adapters.SQL.Sandbox
 
 # Fast testing only

--- a/lib/safira/accounts/attendee.ex
+++ b/lib/safira/accounts/attendee.ex
@@ -7,6 +7,8 @@ defmodule Safira.Accounts.Attendee do
   alias Safira.Contest.Redeem
   alias Safira.Contest.Badge
   alias Safira.Contest.Referral
+  alias Safira.Roulette.Prize
+  alias Safira.Roulette.AttendeePrize
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @derive {Phoenix.Param, key: :id}
@@ -22,6 +24,7 @@ defmodule Safira.Accounts.Attendee do
     belongs_to :user, User
     many_to_many :badges, Badge, join_through: Redeem
     has_many :referrals, Referral
+    many_to_many :prizes, Prize, join_through: AttendeePrize
 
     field :badge_count, :integer, default: 0, virtual: true
 

--- a/lib/safira/roulette.ex
+++ b/lib/safira/roulette.ex
@@ -70,7 +70,7 @@ defmodule Safira.Roulette do
   """
   def update_prize(%Prize{} = prize, attrs) do
     prize
-    |> Prize.changeset(attrs)
+    |> Prize.update_changeset(attrs)
     |> Repo.update()
   end
 

--- a/lib/safira/roulette.ex
+++ b/lib/safira/roulette.ex
@@ -6,100 +6,194 @@ defmodule Safira.Roulette do
   import Ecto.Query, warn: false
   alias Safira.Repo
 
-alias Safira.Roulette.Prize
+  alias Safira.Roulette.Prize
+  alias Safira.Roulette.AttendeePrize
 
-@doc """
-Returns the list of prizes.
+  @doc """
+  Returns the list of prizes.
 
-## Examples
+  ## Examples
 
-    iex> list_prizes()
-    [%Prize{}, ...]
+      iex> list_prizes()
+      [%Prize{}, ...]
 
-"""
-def list_prizes do
-  Repo.all(Prize)
-end
+  """
+  def list_prizes do
+    Repo.all(Prize)
+  end
 
-@doc """
-Gets a single prize.
+  @doc """
+  Gets a single prize.
 
-Raises `Ecto.NoResultsError` if the Prize does not exist.
+  Raises `Ecto.NoResultsError` if the Prize does not exist.
 
-## Examples
+  ## Examples
 
-    iex> get_prize!(123)
+      iex> get_prize!(123)
+      %Prize{}
+
+      iex> get_prize!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_prize!(id), do: Repo.get!(Prize, id)
+
+  @doc """
+  Creates a prize.
+
+  ## Examples
+
+      iex> create_prize(%{field: value})
+      {:ok, %Prize{}}
+
+      iex> create_prize(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_prize(attrs \\ %{}) do
     %Prize{}
+    |> Prize.changeset(attrs)
+    |> Repo.insert()
+  end
 
-    iex> get_prize!(456)
-    ** (Ecto.NoResultsError)
+  @doc """
+  Updates a prize.
 
-"""
-def get_prize!(id), do: Repo.get!(Prize, id)
+  ## Examples
 
-@doc """
-Creates a prize.
+      iex> update_prize(prize, %{field: new_value})
+      {:ok, %Prize{}}
 
-## Examples
+      iex> update_prize(prize, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
 
-    iex> create_prize(%{field: value})
-    {:ok, %Prize{}}
+  """
+  def update_prize(%Prize{} = prize, attrs) do
+    prize
+    |> Prize.changeset(attrs)
+    |> Repo.update()
+  end
 
-    iex> create_prize(%{field: bad_value})
-    {:error, %Ecto.Changeset{}}
+  @doc """
+  Deletes a Prize.
 
-"""
-def create_prize(attrs \\ %{}) do
-  %Prize{}
-  |> Prize.changeset(attrs)
-  |> Repo.insert()
-end
+  ## Examples
 
-@doc """
-Updates a prize.
+      iex> delete_prize(prize)
+      {:ok, %Prize{}}
 
-## Examples
+      iex> delete_prize(prize)
+      {:error, %Ecto.Changeset{}}
 
-    iex> update_prize(prize, %{field: new_value})
-    {:ok, %Prize{}}
+  """
+  def delete_prize(%Prize{} = prize) do
+    Repo.delete(prize)
+  end
 
-    iex> update_prize(prize, %{field: bad_value})
-    {:error, %Ecto.Changeset{}}
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking prize changes.
 
-"""
-def update_prize(%Prize{} = prize, attrs) do
-  prize
-  |> Prize.changeset(attrs)
-  |> Repo.update()
-end
+  ## Examples
 
-@doc """
-Deletes a Prize.
+      iex> change_prize(prize)
+      %Ecto.Changeset{source: %Prize{}}
 
-## Examples
+  """
+  def change_prize(%Prize{} = prize) do
+    Prize.changeset(prize, %{})
+  end
 
-    iex> delete_prize(prize)
-    {:ok, %Prize{}}
+  @doc """
+  Returns the list of attendees_prizes.
 
-    iex> delete_prize(prize)
-    {:error, %Ecto.Changeset{}}
+  ## Examples
 
-"""
-def delete_prize(%Prize{} = prize) do
-  Repo.delete(prize)
-end
+      iex> list_attendees_prizes()
+      [%AttendeePrize{}, ...]
 
-@doc """
-Returns an `%Ecto.Changeset{}` for tracking prize changes.
+  """
+  def list_attendees_prizes do
+    Repo.all(AttendeePrize)
+  end
 
-## Examples
+  @doc """
+  Gets a single attendee_prize.
 
-    iex> change_prize(prize)
-    %Ecto.Changeset{source: %Prize{}}
+  Raises `Ecto.NoResultsError` if the Attendee prize does not exist.
 
-"""
-def change_prize(%Prize{} = prize) do
-  Prize.changeset(prize, %{})
-end
+  ## Examples
 
+      iex> get_attendee_prize!(123)
+      %AttendeePrize{}
+
+      iex> get_attendee_prize!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_attendee_prize!(id), do: Repo.get!(AttendeePrize, id)
+
+  @doc """
+  Creates a attendee_prize.
+
+  ## Examples
+
+      iex> create_attendee_prize(%{field: value})
+      {:ok, %AttendeePrize{}}
+
+      iex> create_attendee_prize(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_attendee_prize(attrs \\ %{}) do
+    %AttendeePrize{}
+    |> AttendeePrize.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a attendee_prize.
+
+  ## Examples
+
+      iex> update_attendee_prize(attendee_prize, %{field: new_value})
+      {:ok, %AttendeePrize{}}
+
+      iex> update_attendee_prize(attendee_prize, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_attendee_prize(%AttendeePrize{} = attendee_prize, attrs) do
+    attendee_prize
+    |> AttendeePrize.update_changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a AttendeePrize.
+
+  ## Examples
+
+      iex> delete_attendee_prize(attendee_prize)
+      {:ok, %AttendeePrize{}}
+
+      iex> delete_attendee_prize(attendee_prize)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_attendee_prize(%AttendeePrize{} = attendee_prize) do
+    Repo.delete(attendee_prize)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking attendee_prize changes.
+
+  ## Examples
+
+      iex> change_attendee_prize(attendee_prize)
+      %Ecto.Changeset{source: %AttendeePrize{}}
+
+  """
+  def change_attendee_prize(%AttendeePrize{} = attendee_prize) do
+    AttendeePrize.changeset(attendee_prize, %{})
+  end
 end

--- a/lib/safira/roulette.ex
+++ b/lib/safira/roulette.ex
@@ -164,7 +164,7 @@ defmodule Safira.Roulette do
   """
   def update_attendee_prize(%AttendeePrize{} = attendee_prize, attrs) do
     attendee_prize
-    |> AttendeePrize.update_changeset(attrs)
+    |> AttendeePrize.changeset(attrs)
     |> Repo.update()
   end
 

--- a/lib/safira/roulette.ex
+++ b/lib/safira/roulette.ex
@@ -1,0 +1,105 @@
+defmodule Safira.Roulette do
+  @moduledoc """
+  The Roulette context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Safira.Repo
+
+alias Safira.Roulette.Prize
+
+@doc """
+Returns the list of prizes.
+
+## Examples
+
+    iex> list_prizes()
+    [%Prize{}, ...]
+
+"""
+def list_prizes do
+  Repo.all(Prize)
+end
+
+@doc """
+Gets a single prize.
+
+Raises `Ecto.NoResultsError` if the Prize does not exist.
+
+## Examples
+
+    iex> get_prize!(123)
+    %Prize{}
+
+    iex> get_prize!(456)
+    ** (Ecto.NoResultsError)
+
+"""
+def get_prize!(id), do: Repo.get!(Prize, id)
+
+@doc """
+Creates a prize.
+
+## Examples
+
+    iex> create_prize(%{field: value})
+    {:ok, %Prize{}}
+
+    iex> create_prize(%{field: bad_value})
+    {:error, %Ecto.Changeset{}}
+
+"""
+def create_prize(attrs \\ %{}) do
+  %Prize{}
+  |> Prize.changeset(attrs)
+  |> Repo.insert()
+end
+
+@doc """
+Updates a prize.
+
+## Examples
+
+    iex> update_prize(prize, %{field: new_value})
+    {:ok, %Prize{}}
+
+    iex> update_prize(prize, %{field: bad_value})
+    {:error, %Ecto.Changeset{}}
+
+"""
+def update_prize(%Prize{} = prize, attrs) do
+  prize
+  |> Prize.changeset(attrs)
+  |> Repo.update()
+end
+
+@doc """
+Deletes a Prize.
+
+## Examples
+
+    iex> delete_prize(prize)
+    {:ok, %Prize{}}
+
+    iex> delete_prize(prize)
+    {:error, %Ecto.Changeset{}}
+
+"""
+def delete_prize(%Prize{} = prize) do
+  Repo.delete(prize)
+end
+
+@doc """
+Returns an `%Ecto.Changeset{}` for tracking prize changes.
+
+## Examples
+
+    iex> change_prize(prize)
+    %Ecto.Changeset{source: %Prize{}}
+
+"""
+def change_prize(%Prize{} = prize) do
+  Prize.changeset(prize, %{})
+end
+
+end

--- a/lib/safira/roulette/attendee_prize.ex
+++ b/lib/safira/roulette/attendee_prize.ex
@@ -1,0 +1,31 @@
+defmodule Safira.Roulette.AttendeePrize do
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias Safira.Accounts.Attendee
+  alias Safira.Roulette.Prize
+
+  schema "attendees_prizes" do
+    field :quantity, :integer
+
+    belongs_to :attendee, Attendee, foreign_key: :attendee_id, type: :binary_id
+    belongs_to :prize, Prize
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(attendee_prize, attrs) do
+    attendee_prize
+    |> cast(attrs, [:quantity, :attendee_id, :prize_id])
+    |> validate_required([:quantity, :attendee_id, :prize_id])
+    |> unique_constraint(:unique_attendee_prize)
+    |> validate_number(:quantity, greater_than: 0)
+  end
+
+  def update_changeset(attendee_prize, attrs) do
+    attendee_prize
+    |> cast(attrs, [:quantity, :attendee_id, :prize_id])
+    |> validate_required([:quantity, :attendee_id, :prize_id])
+    |> validate_number(:quantity, greater_than: 0)
+  end
+end

--- a/lib/safira/roulette/attendee_prize.ex
+++ b/lib/safira/roulette/attendee_prize.ex
@@ -21,11 +21,4 @@ defmodule Safira.Roulette.AttendeePrize do
     |> unique_constraint(:unique_attendee_prize)
     |> validate_number(:quantity, greater_than: 0)
   end
-
-  def update_changeset(attendee_prize, attrs) do
-    attendee_prize
-    |> cast(attrs, [:quantity, :attendee_id, :prize_id])
-    |> validate_required([:quantity, :attendee_id, :prize_id])
-    |> validate_number(:quantity, greater_than: 0)
-  end
 end

--- a/lib/safira/roulette/attendee_prize.ex
+++ b/lib/safira/roulette/attendee_prize.ex
@@ -3,6 +3,7 @@ defmodule Safira.Roulette.AttendeePrize do
   import Ecto.Changeset
   alias Safira.Accounts.Attendee
   alias Safira.Roulette.Prize
+  alias Safira.Repo
 
   schema "attendees_prizes" do
     field :quantity, :integer
@@ -20,5 +21,38 @@ defmodule Safira.Roulette.AttendeePrize do
     |> validate_required([:quantity, :attendee_id, :prize_id])
     |> unique_constraint(:unique_attendee_prize)
     |> validate_number(:quantity, greater_than: 0)
+    |> validate_quantity
+  end
+
+  defp validate_quantity(changeset) do
+    {_, prize_id} = fetch_field(changeset, :prize_id)
+    {_, quantity} = fetch_field(changeset, :quantity)
+
+    case {prize_id, quantity} do
+      {nil, nil} ->
+        add_error(changeset, :prize_id, "Prize shouldn't be nil")
+        add_error(changeset, :quantity, "Quantity shouldn't be nil")
+
+      {nil, _} ->
+        add_error(changeset, :prize_id, "Prize shouldn't be nil")
+
+      {_, nil} ->
+        add_error(changeset, :quantity, "Quantity shouldn't be nil")
+
+      {_, _} ->
+        prize = Prize |> Repo.get(prize_id)
+
+        cond do
+          prize.max_amount_per_attendee >= quantity ->
+            changeset
+
+          true ->
+            add_error(
+              changeset,
+              :quantity,
+              "Quantity is greater than the maximum amount permitted per attendee"
+            )
+        end
+    end
   end
 end

--- a/lib/safira/roulette/prize.ex
+++ b/lib/safira/roulette/prize.ex
@@ -4,6 +4,7 @@ defmodule Safira.Roulette.Prize do
   import Ecto.Changeset
 
   alias Safira.Accounts.Attendee
+  alias Safira.Roulette.AttendeePrize
 
   schema "prizes" do
     field :name, :string

--- a/lib/safira/roulette/prize.ex
+++ b/lib/safira/roulette/prize.ex
@@ -1,0 +1,28 @@
+defmodule Safira.Roulette.Prize do
+  use Ecto.Schema
+  use Arc.Ecto.Schema
+  import Ecto.Changeset
+
+  schema "prizes" do
+    field :name, :string
+    field :stock, :integer
+    field :max_amount_per_attendee, :integer
+    field :probability, :float
+    field :avatar, Safira.Avatar.Type
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(prize, attrs) do
+    prize
+    |> cast(attrs, [:name, :stock, :max_amount_per_attendee, :probability])
+    |> cast_attachments(attrs, [:avatar])
+    |> validate_required([:name, :stock, :max_amount_per_attendee, :probability])
+    |> (&validate_number(&1, :stock,
+          greater_than_or_equal_to:
+            fetch_field(&1, :max_amount_per_attendee) |> Tuple.to_list() |> List.last()
+        )).()
+    |> validate_number(:probability, greater_than_or_equal_to: 0, less_than_or_equal_to: 1)
+  end
+end

--- a/lib/safira/roulette/prize.ex
+++ b/lib/safira/roulette/prize.ex
@@ -3,12 +3,16 @@ defmodule Safira.Roulette.Prize do
   use Arc.Ecto.Schema
   import Ecto.Changeset
 
+  alias Safira.Accounts.Attendee
+
   schema "prizes" do
     field :name, :string
     field :stock, :integer
     field :max_amount_per_attendee, :integer
     field :probability, :float
     field :avatar, Safira.Avatar.Type
+
+    many_to_many :attendees, Attendee, join_through: AttendeePrize
 
     timestamps()
   end
@@ -20,8 +24,7 @@ defmodule Safira.Roulette.Prize do
     |> cast_attachments(attrs, [:avatar])
     |> validate_required([:name, :stock, :max_amount_per_attendee, :probability])
     |> (&validate_number(&1, :stock,
-          greater_than_or_equal_to:
-            fetch_field(&1, :max_amount_per_attendee) |> Tuple.to_list() |> List.last()
+          greater_than_or_equal_to: fetch_field(&1, :max_amount_per_attendee) |> elem(1)
         )).()
     |> validate_number(:probability, greater_than_or_equal_to: 0, less_than_or_equal_to: 1)
   end

--- a/lib/safira/roulette/prize.ex
+++ b/lib/safira/roulette/prize.ex
@@ -23,9 +23,20 @@ defmodule Safira.Roulette.Prize do
     |> cast(attrs, [:name, :stock, :max_amount_per_attendee, :probability])
     |> cast_attachments(attrs, [:avatar])
     |> validate_required([:name, :stock, :max_amount_per_attendee, :probability])
+    |> validate_number(:max_amount_per_attendee, greater_than: 0)
     |> (&validate_number(&1, :stock,
           greater_than_or_equal_to: fetch_field(&1, :max_amount_per_attendee) |> elem(1)
         )).()
+    |> validate_number(:probability, greater_than_or_equal_to: 0, less_than_or_equal_to: 1)
+  end
+
+  def update_changeset(prize, attrs) do
+    prize
+    |> cast(attrs, [:name, :stock, :max_amount_per_attendee, :probability])
+    |> cast_attachments(attrs, [:avatar])
+    |> validate_required([:name, :stock, :max_amount_per_attendee, :probability])
+    |> validate_number(:max_amount_per_attendee, greater_than: 0)
+    |> validate_number(:stock, greater_than: 0)
     |> validate_number(:probability, greater_than_or_equal_to: 0, less_than_or_equal_to: 1)
   end
 end

--- a/priv/repo/migrations/20210209190634_create_prizes.exs
+++ b/priv/repo/migrations/20210209190634_create_prizes.exs
@@ -11,6 +11,5 @@ defmodule Safira.Repo.Migrations.CreatePrizes do
 
       timestamps()
     end
-
   end
 end

--- a/priv/repo/migrations/20210209190634_create_prizes.exs
+++ b/priv/repo/migrations/20210209190634_create_prizes.exs
@@ -1,0 +1,16 @@
+defmodule Safira.Repo.Migrations.CreatePrizes do
+  use Ecto.Migration
+
+  def change do
+    create table(:prizes) do
+      add :name, :string
+      add :stock, :integer
+      add :probability, :float
+      add :avatar, :string
+      add :max_amount_per_attendee, :integer
+
+      timestamps()
+    end
+
+  end
+end

--- a/priv/repo/migrations/20210209232425_create_attendees_prizes.exs
+++ b/priv/repo/migrations/20210209232425_create_attendees_prizes.exs
@@ -1,0 +1,18 @@
+defmodule Safira.Repo.Migrations.CreateAttendeesPrizes do
+  use Ecto.Migration
+
+  def change do
+    create table(:attendees_prizes) do
+      add :quantity, :integer
+      add :attendee_id, references(:attendees, on_delete: :delete_all, type: :uuid)
+      add :prize_id, references(:prizes, on_delete: :delete_all)
+
+      timestamps()
+    end
+
+    create index(:attendees_prizes, [:attendee_id])
+    create index(:attendees_prizes, [:prize_id])
+
+    create unique_index(:attendees_prizes, [:attendee_id, :prize_id], name: :unique_attendee_prize)
+  end
+end

--- a/test/factories/prize_factory.ex
+++ b/test/factories/prize_factory.ex
@@ -1,0 +1,14 @@
+defmodule Safira.PrizeFactory do
+  defmacro __using__(_opts) do
+    quote do
+      def prize_factory do
+        %Safira.Roulette.Prize{
+          max_amount_per_attendee: 10,
+          name: "Prize test name",
+          probability: 0.5,
+          stock: 40
+        }
+      end
+    end
+  end
+end

--- a/test/safira/roulette_test.exs
+++ b/test/safira/roulette_test.exs
@@ -162,21 +162,34 @@ defmodule Safira.RouletteTest do
 
     test "update_attendee_prize/2 with invalid data returns error changeset" do
       attendee_prize = attendee_prize_fixture()
+
       # invalid quantity
       assert {:error, %Ecto.Changeset{}} =
                Roulette.update_attendee_prize(attendee_prize, %{quantity: 0})
 
       assert attendee_prize == Roulette.get_attendee_prize!(attendee_prize.id)
+
       # invalid attendee_id
       assert {:error, %Ecto.Changeset{}} =
                Roulette.update_attendee_prize(attendee_prize, %{attendee_id: nil})
 
       assert attendee_prize == Roulette.get_attendee_prize!(attendee_prize.id)
+
       # invalid prize_id
       assert {:error, %Ecto.Changeset{}} =
                Roulette.update_attendee_prize(attendee_prize, %{prize_id: nil})
 
       assert attendee_prize == Roulette.get_attendee_prize!(attendee_prize.id)
+    end
+
+    test "update_attendee_prize/2 with quantity greater than the maximum per attendee" do
+      attendee_prize = attendee_prize_fixture()
+      prize = Roulette.get_prize!(attendee_prize.prize_id)
+
+      assert {:error, %Ecto.Changeset{}} =
+               Roulette.update_attendee_prize(attendee_prize, %{
+                 quantity: prize.max_amount_per_attendee + 1
+               })
     end
 
     test "delete_attendee_prize/1 deletes the attendee_prize" do

--- a/test/safira/roulette_test.exs
+++ b/test/safira/roulette_test.exs
@@ -7,9 +7,19 @@ defmodule Safira.RouletteTest do
     alias Safira.Roulette.Prize
 
     @valid_attrs %{max_amount_per_attendee: 10, name: "some name", probability: 0.42, stock: 40}
-    @update_attrs %{max_amount_per_attendee: 10, name: "some updated name", probability: 0.61, stock: 50}
+    @update_attrs %{
+      max_amount_per_attendee: 10,
+      name: "some updated name",
+      probability: 0.61,
+      stock: 50
+    }
     @invalid_attrs1 %{max_amount_per_attendee: nil, name: nil, probability: nil, stock: nil}
-    @invalid_attrs2 %{max_amount_per_attendee: 11, name: "some name", probability: 0.42, stock: 10}
+    @invalid_attrs2 %{
+      max_amount_per_attendee: 11,
+      name: "some name",
+      probability: 0.42,
+      stock: 10
+    }
     @invalid_attrs3 %{max_amount_per_attendee: 9, name: "some name", probability: -0.7, stock: 10}
     @invalid_attrs4 %{max_amount_per_attendee: 9, name: "some name", probability: 1.7, stock: 10}
 
@@ -80,4 +90,68 @@ defmodule Safira.RouletteTest do
       assert %Ecto.Changeset{} = Roulette.change_prize(prize)
     end
   end
+
+  """
+  describe "attendees_prizes" do
+    alias Safira.Roulette.AttendeePrize
+
+    @valid_attrs %{attendee_id: "7c2c5f14-1570-4655-b296-a3d6fe7af430", prize_id: 1, quantity: 42}
+    @update_attrs %{attendee_id: "7c2c5f14-1570-4655-b296-a3d6fe7af430", prize_id: 1, quantity: 43}
+    @invalid_attrs %{attendee_id: nil, prize_id: nil, quantity: nil}
+
+    def attendee_prize_fixture(attrs \\ %{}) do
+      {:ok, attendee_prize} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Roulette.create_attendee_prize()
+
+      attendee_prize
+    end
+
+    test "list_attendees_prizes/0 returns all attendees_prizes" do
+      attendee = insert(:attendee)
+      IO.inspect(attendee)
+      attendee_prize = attendee_prize_fixture()
+      assert Roulette.list_attendees_prizes() == [attendee_prize]
+    end
+
+    test "get_attendee_prize!/1 returns the attendee_prize with given id" do
+      attendee_prize = attendee_prize_fixture()
+      assert Roulette.get_attendee_prize!(attendee_prize.id) == attendee_prize
+    end
+
+    test "create_attendee_prize/1 with valid data creates a attendee_prize" do
+      assert {:ok, %AttendeePrize{} = attendee_prize} = Roulette.create_attendee_prize(@valid_attrs)
+      assert attendee_prize.quantity == 42
+    end
+
+    test "create_attendee_prize/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Roulette.create_attendee_prize(@invalid_attrs)
+    end
+
+    test "update_attendee_prize/2 with valid data updates the attendee_prize" do
+      attendee_prize = attendee_prize_fixture()
+      assert {:ok, attendee_prize} = Roulette.update_attendee_prize(attendee_prize, @update_attrs)
+      assert %AttendeePrize{} = attendee_prize
+      assert attendee_prize.quantity == 43
+    end
+
+    test "update_attendee_prize/2 with invalid data returns error changeset" do
+      attendee_prize = attendee_prize_fixture()
+      assert {:error, %Ecto.Changeset{}} = Roulette.update_attendee_prize(attendee_prize, @invalid_attrs)
+      assert attendee_prize == Roulette.get_attendee_prize!(attendee_prize.id)
+    end
+
+    test "delete_attendee_prize/1 deletes the attendee_prize" do
+      attendee_prize = attendee_prize_fixture()
+      assert {:ok, %AttendeePrize{}} = Roulette.delete_attendee_prize(attendee_prize)
+      assert_raise Ecto.NoResultsError, fn -> Roulette.get_attendee_prize!(attendee_prize.id) end
+    end
+
+    test "change_attendee_prize/1 returns a attendee_prize changeset" do
+      attendee_prize = attendee_prize_fixture()
+      assert %Ecto.Changeset{} = Roulette.change_attendee_prize(attendee_prize)
+    end
+  end
+  """
 end

--- a/test/safira/roulette_test.exs
+++ b/test/safira/roulette_test.exs
@@ -8,7 +8,7 @@ defmodule Safira.RouletteTest do
 
     @valid_attrs %{max_amount_per_attendee: 10, name: "some name", probability: 0.42, stock: 40}
     @update_attrs %{
-      max_amount_per_attendee: 10,
+      max_amount_per_attendee: 51,
       name: "some updated name",
       probability: 0.61,
       stock: 50
@@ -61,7 +61,7 @@ defmodule Safira.RouletteTest do
       prize = prize_fixture()
       assert {:ok, prize} = Roulette.update_prize(prize, @update_attrs)
       assert %Prize{} = prize
-      assert prize.max_amount_per_attendee == 10
+      assert prize.max_amount_per_attendee == 51
       assert prize.name == "some updated name"
       assert prize.probability == 0.61
       assert prize.stock == 50
@@ -70,8 +70,6 @@ defmodule Safira.RouletteTest do
     test "update_prize/2 with invalid data returns error changeset" do
       prize = prize_fixture()
       assert {:error, %Ecto.Changeset{}} = Roulette.update_prize(prize, @invalid_attrs1)
-      assert prize == Roulette.get_prize!(prize.id)
-      assert {:error, %Ecto.Changeset{}} = Roulette.update_prize(prize, @invalid_attrs2)
       assert prize == Roulette.get_prize!(prize.id)
       assert {:error, %Ecto.Changeset{}} = Roulette.update_prize(prize, @invalid_attrs3)
       assert prize == Roulette.get_prize!(prize.id)

--- a/test/safira/roulette_test.exs
+++ b/test/safira/roulette_test.exs
@@ -129,7 +129,9 @@ defmodule Safira.RouletteTest do
       {attendee, prize} = setup()
       attendee_prize = %{attendee_id: attendee.id, prize_id: prize.id, quantity: 1}
 
-      assert {:ok, %AttendeePrize{} = returned_attendee_prize} = Roulette.create_attendee_prize(attendee_prize)
+      assert {:ok, %AttendeePrize{} = returned_attendee_prize} =
+               Roulette.create_attendee_prize(attendee_prize)
+
       assert returned_attendee_prize.attendee_id == attendee.id
       assert returned_attendee_prize.prize_id == prize.id
       assert returned_attendee_prize.quantity == 1
@@ -152,7 +154,10 @@ defmodule Safira.RouletteTest do
 
     test "update_attendee_prize/2 with valid data updates the attendee_prize" do
       attendee_prize = attendee_prize_fixture()
-      assert {:ok, attendee_prize} = Roulette.update_attendee_prize(attendee_prize, %{quantity: 5})
+
+      assert {:ok, attendee_prize} =
+               Roulette.update_attendee_prize(attendee_prize, %{quantity: 5})
+
       assert %AttendeePrize{} = attendee_prize
       assert attendee_prize.quantity == 5
     end
@@ -160,13 +165,19 @@ defmodule Safira.RouletteTest do
     test "update_attendee_prize/2 with invalid data returns error changeset" do
       attendee_prize = attendee_prize_fixture()
       # invalid quantity
-      assert {:error, %Ecto.Changeset{}} = Roulette.update_attendee_prize(attendee_prize, %{quantity: 0})
+      assert {:error, %Ecto.Changeset{}} =
+               Roulette.update_attendee_prize(attendee_prize, %{quantity: 0})
+
       assert attendee_prize == Roulette.get_attendee_prize!(attendee_prize.id)
       # invalid attendee_id
-      assert {:error, %Ecto.Changeset{}} = Roulette.update_attendee_prize(attendee_prize, %{attendee_id: nil})
+      assert {:error, %Ecto.Changeset{}} =
+               Roulette.update_attendee_prize(attendee_prize, %{attendee_id: nil})
+
       assert attendee_prize == Roulette.get_attendee_prize!(attendee_prize.id)
       # invalid prize_id
-      assert {:error, %Ecto.Changeset{}} = Roulette.update_attendee_prize(attendee_prize, %{prize_id: nil})
+      assert {:error, %Ecto.Changeset{}} =
+               Roulette.update_attendee_prize(attendee_prize, %{prize_id: nil})
+
       assert attendee_prize == Roulette.get_attendee_prize!(attendee_prize.id)
     end
 
@@ -181,5 +192,4 @@ defmodule Safira.RouletteTest do
       assert %Ecto.Changeset{} = Roulette.change_attendee_prize(attendee_prize)
     end
   end
-
 end

--- a/test/safira/roulette_test.exs
+++ b/test/safira/roulette_test.exs
@@ -1,0 +1,83 @@
+defmodule Safira.RouletteTest do
+  use Safira.DataCase
+
+  alias Safira.Roulette
+
+  describe "prizes" do
+    alias Safira.Roulette.Prize
+
+    @valid_attrs %{max_amount_per_attendee: 10, name: "some name", probability: 0.42, stock: 40}
+    @update_attrs %{max_amount_per_attendee: 10, name: "some updated name", probability: 0.61, stock: 50}
+    @invalid_attrs1 %{max_amount_per_attendee: nil, name: nil, probability: nil, stock: nil}
+    @invalid_attrs2 %{max_amount_per_attendee: 11, name: "some name", probability: 0.42, stock: 10}
+    @invalid_attrs3 %{max_amount_per_attendee: 9, name: "some name", probability: -0.7, stock: 10}
+    @invalid_attrs4 %{max_amount_per_attendee: 9, name: "some name", probability: 1.7, stock: 10}
+
+    def prize_fixture(attrs \\ %{}) do
+      {:ok, prize} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Roulette.create_prize()
+
+      prize
+    end
+
+    test "list_prizes/0 returns all prizes" do
+      prize = prize_fixture()
+      assert Roulette.list_prizes() == [prize]
+    end
+
+    test "get_prize!/1 returns the prize with given id" do
+      prize = prize_fixture()
+      assert Roulette.get_prize!(prize.id) == prize
+    end
+
+    test "create_prize/1 with valid data creates a prize" do
+      assert {:ok, %Prize{} = prize} = Roulette.create_prize(@valid_attrs)
+      assert prize.max_amount_per_attendee == 10
+      assert prize.name == "some name"
+      assert prize.probability == 0.42
+      assert prize.stock == 40
+    end
+
+    test "create_prize/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Roulette.create_prize(@invalid_attrs1)
+      assert {:error, %Ecto.Changeset{}} = Roulette.create_prize(@invalid_attrs2)
+      assert {:error, %Ecto.Changeset{}} = Roulette.create_prize(@invalid_attrs3)
+      assert {:error, %Ecto.Changeset{}} = Roulette.create_prize(@invalid_attrs4)
+    end
+
+    test "update_prize/2 with valid data updates the prize" do
+      prize = prize_fixture()
+      assert {:ok, prize} = Roulette.update_prize(prize, @update_attrs)
+      assert %Prize{} = prize
+      assert prize.max_amount_per_attendee == 10
+      assert prize.name == "some updated name"
+      assert prize.probability == 0.61
+      assert prize.stock == 50
+    end
+
+    test "update_prize/2 with invalid data returns error changeset" do
+      prize = prize_fixture()
+      assert {:error, %Ecto.Changeset{}} = Roulette.update_prize(prize, @invalid_attrs1)
+      assert prize == Roulette.get_prize!(prize.id)
+      assert {:error, %Ecto.Changeset{}} = Roulette.update_prize(prize, @invalid_attrs2)
+      assert prize == Roulette.get_prize!(prize.id)
+      assert {:error, %Ecto.Changeset{}} = Roulette.update_prize(prize, @invalid_attrs3)
+      assert prize == Roulette.get_prize!(prize.id)
+      assert {:error, %Ecto.Changeset{}} = Roulette.update_prize(prize, @invalid_attrs4)
+      assert prize == Roulette.get_prize!(prize.id)
+    end
+
+    test "delete_prize/1 deletes the prize" do
+      prize = prize_fixture()
+      assert {:ok, %Prize{}} = Roulette.delete_prize(prize)
+      assert_raise Ecto.NoResultsError, fn -> Roulette.get_prize!(prize.id) end
+    end
+
+    test "change_prize/1 returns a prize changeset" do
+      prize = prize_fixture()
+      assert %Ecto.Changeset{} = Roulette.change_prize(prize)
+    end
+  end
+end

--- a/test/safira/roulette_test.exs
+++ b/test/safira/roulette_test.exs
@@ -94,7 +94,7 @@ defmodule Safira.RouletteTest do
   describe "attendees_prizes" do
     alias Safira.Roulette.AttendeePrize
 
-    @invalid_attrs %{attendee_id: nil, prize_id: nil, quantity: 1}
+    @invalid_attrs %{attendee_id: nil, prize_id: nil, quantity: nil}
 
     def setup() do
       user = create_user_strategy(:user)
@@ -105,7 +105,7 @@ defmodule Safira.RouletteTest do
 
     def attendee_prize_fixture(attrs \\ %{}) do
       {attendee, prize} = setup()
-      attendee_prize = %{attendee_id: attendee.id, prize_id: prize.id, quantity: nil}
+      attendee_prize = %{attendee_id: attendee.id, prize_id: prize.id, quantity: 1}
 
       {:ok, returned_attendee_prize} =
         attrs

--- a/test/strategies/prize_strategy.ex
+++ b/test/strategies/prize_strategy.ex
@@ -1,0 +1,12 @@
+defmodule Safira.PrizeStrategy do
+  use ExMachina.Strategy, function_name: :create_prize_strategy
+
+  def handle_create_prize_strategy(record, _opts) do
+    {:ok, prize} = Safira.Roulette.create_prize(
+                    %{max_amount_per_attendee: record.max_amount_per_attendee,
+                      name: record.name,
+                      probability: record.probability,
+                      stock: record.stock})
+    prize
+  end
+end

--- a/test/strategies/prize_strategy.ex
+++ b/test/strategies/prize_strategy.ex
@@ -2,11 +2,14 @@ defmodule Safira.PrizeStrategy do
   use ExMachina.Strategy, function_name: :create_prize_strategy
 
   def handle_create_prize_strategy(record, _opts) do
-    {:ok, prize} = Safira.Roulette.create_prize(
-                    %{max_amount_per_attendee: record.max_amount_per_attendee,
-                      name: record.name,
-                      probability: record.probability,
-                      stock: record.stock})
+    {:ok, prize} =
+      Safira.Roulette.create_prize(%{
+        max_amount_per_attendee: record.max_amount_per_attendee,
+        name: record.name,
+        probability: record.probability,
+        stock: record.stock
+      })
+
     prize
   end
 end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -23,6 +23,7 @@ defmodule Safira.DataCase do
       import Ecto
       import Ecto.Changeset
       import Ecto.Query
+      import Safira.Factory
       import Safira.DataCase
     end
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -5,4 +5,6 @@ defmodule Safira.Factory do
   use Safira.AttendeeFactory
   use Safira.BadgeFactory
   use Safira.RedeemFactory
+  use Safira.PrizeStrategy
+  use Safira.PrizeFactory
 end


### PR DESCRIPTION
Add a new Context named Roulette, with 2 schemas. 
Prize represents a prize that an attendee can win by playing roulette.
AttendeePrice represents the intermediate table between the many to many Attendee-Prize association, and includes the quantity field which represents the number of times that an attendee won that Prize.

Some tests were automatically added, but I still changed a few things to make it work properly. (strategy and factory)
