### PR TITLE
Turn gift checkpoint badges task to a generic task

### DIFF
--- a/doc/endpoints.md
+++ b/doc/endpoints.md
@@ -234,7 +234,7 @@ any calls to the api that need to be authenticated.
 
 # badges
 ## GET / (Index)
-Fetches the badges of the logged in attendee.
+Fetches all badges depending in the type of user that is consulting them.
 
 ### Valid:
 ```json
@@ -573,7 +573,7 @@ Removes an attendee.
             "badges": 28,
             "id": "79a29c1c-9f2e-4de1-a318-54eb1e6ec060",
             "name": "user1",
-            "nickname": "jpsilva98",
+            "nickname": "user1",
             "token_balance": 80,
             "volunteer": false
         },

--- a/lib/mix/tasks/gift.company.checkpoint.badge.ex
+++ b/lib/mix/tasks/gift.company.checkpoint.badge.ex
@@ -20,12 +20,13 @@ defmodule Mix.Tasks.Gift.Company.Checkpoint.Badge do
           to receive the checkpoint basge
       - entries: Number of entries that an attendee receives for
           having this badge
+      - badge_type: type of badge to confirm
   """
 
   def run(args) do
     cond do
-      length(args) != 3 ->
-        Mix.shell().info("Needs to receive badge_id, badge_count and entries.")
+      length(args) != 4 ->
+        Mix.shell().info("Needs to receive badge_id, badge_count, entries and badge_type.")
 
       true ->
         args |> create()
@@ -55,7 +56,8 @@ defmodule Mix.Tasks.Gift.Company.Checkpoint.Badge do
     %{
       badge_id: Enum.at(args, 0),
       badge_count: Enum.at(args, 1),
-      entries: Enum.at(args, 2)
+      entries: Enum.at(args, 2),
+      badge_type: Enum.at(args, 3),
     }
   end
 
@@ -76,7 +78,7 @@ defmodule Mix.Tasks.Gift.Company.Checkpoint.Badge do
       from a in Attendee,
       join: r in Redeem, on: a.id == r.attendee_id,
       join: b in Badge, on: r.badge_id == b.id,
-      where: b.type == 4,
+      where: b.type == ^Map.get(args, :badge_type),
       preload: [badges: b]
     )
     |> Enum.map(fn a -> Map.put(a, :badge_count, length(a.badges)) end)

--- a/lib/safira/contest/badge.ex
+++ b/lib/safira/contest/badge.ex
@@ -13,7 +13,7 @@ defmodule Safira.Contest.Badge do
     field :name, :string
     field :description, :string
     field :avatar, Safira.Avatar.Type
-    #%{hidden: 0, secret: 1, empresa: 2, talk: 3, workshop: 4, oradore: 5, dias: 6, outros: 7}
+    #%{verificações: 0, secret: 1, desafios: 2, dias: 3, empresas: 4, oradores: 5, talks: 6, workshops: 7, outros: 8}
     field :type, :integer
     field :tokens, :integer
 


### PR DESCRIPTION
This PR adds:
- Turn gift checkpoint badges task to a generic task by passing the badge type as an argument;
- Remove badge type inconsistencies in `badge.ex`: #%{verificações: 0, secret: 1, desafios: 2, dias: 3, empresas: 4, oradores: 5, talks: 6, workshops: 7, outros: 8}
- Add some documentation;

Resolves: #178
Resolves: #188 