### PR TITLE
Change sorter because of the Elixir version

### DIFF
--- a/lib/safira/contest/contest.ex
+++ b/lib/safira/contest/contest.ex
@@ -178,7 +178,7 @@ defmodule Safira.Contest do
         preload: [badges: b]
     )
     |> Enum.map(fn a -> Map.put(a, :badge_count, length(a.badges)) end)
-    |> Enum.sort_by(&{&1.badge_count, &1.token_balance}, :desc)
+    |> Enum.sort_by(&{&1.badge_count, &1.token_balance}, &>=/2)
   end
 
   def top_list_leaderboard(n) do


### PR DESCRIPTION
Change sorter because of the Elixir version. `Enum.sort_by` changed the way of putting the sorter function, and Safira uses an older version.