### PR TITLE
Fix daily leaderboard

### DIFF
--- a/lib/safira/accounts/attendee.ex
+++ b/lib/safira/accounts/attendee.ex
@@ -7,6 +7,7 @@ defmodule Safira.Accounts.Attendee do
   alias Safira.Contest.Redeem
   alias Safira.Contest.Badge
   alias Safira.Contest.Referral
+  alias Safira.Contest.DailyToken
   alias Safira.Store.Redeemable
   alias Safira.Store.Buy
   alias Safira.Roulette.Prize
@@ -27,6 +28,7 @@ defmodule Safira.Accounts.Attendee do
     belongs_to :user, User
     many_to_many :badges, Badge, join_through: Redeem
     has_many :referrals, Referral
+    has_many :daily_tokens, DailyToken
     many_to_many :redeemables, Redeemable, join_through: Buy
     many_to_many :prizes, Prize, join_through: AttendeePrize
 

--- a/lib/safira/contest/daily_token.ex
+++ b/lib/safira/contest/daily_token.ex
@@ -1,0 +1,22 @@
+defmodule Safira.Contest.DailyToken do
+  use Ecto.Schema
+  use Arc.Ecto.Schema
+  import Ecto.Changeset
+
+  alias Safira.Accounts.Attendee
+
+  schema "daily_tokens" do
+    belongs_to :attendee, Attendee, foreign_key: :attendee_id, type: :binary_id
+
+    field :day, :utc_datetime
+    field :quantity, :integer
+
+    timestamps()
+  end
+
+  def changeset(redeemable, attrs) do
+    redeemable
+    |> cast(attrs, [:attendee_id, :day, :quantity])
+    |> validate_required([:attendee_id, :day, :quantity])
+  end
+end

--- a/lib/safira/roulette/roulette.ex
+++ b/lib/safira/roulette/roulette.ex
@@ -10,6 +10,7 @@ defmodule Safira.Roulette do
   alias Safira.Roulette.Prize
   alias Safira.Roulette.AttendeePrize
   alias Safira.Accounts.Attendee
+  alias Safira.Contest.DailyToken
 
   @doc """
   Returns the list of prizes.
@@ -262,6 +263,10 @@ defmodule Safira.Roulette do
     # update probabilities if the stock of current prize is 0
     |> Multi.merge(fn %{prize_stock: prize_stock, prize: prize} ->
       update_probabilities(prize_stock, prize)
+    end)
+    |> Multi.insert_or_update(:daily_token, fn %{attendee: attendee} ->
+      {:ok, date, _} = DateTime.from_iso8601("#{Date.utc_today()}T00:00:00Z")
+      DailyToken.changeset(%DailyToken{}, %{quantity: attendee.token_balance, attendee_id: attendee.id, day: date})
     end)
     |> serializable_transaction()
   end

--- a/lib/safira/store/store.ex
+++ b/lib/safira/store/store.ex
@@ -5,6 +5,7 @@ defmodule Safira.Store do
   alias Safira.Store.Redeemable
   alias Safira.Store.Buy
   alias Safira.Accounts.Attendee
+  alias Safira.Contest.DailyToken
 
   def list_redeemables do
     Repo.all(Redeemable)
@@ -79,6 +80,10 @@ defmodule Safira.Store do
     end)
     |> Multi.insert_or_update(:upsert_buy, fn %{buy: buy} ->
       Buy.changeset(buy, %{quantity: buy.quantity + 1})
+    end)
+    |> Multi.insert_or_update(:daily_token, fn %{attendee: attendee} ->
+      {:ok, date, _} = DateTime.from_iso8601("#{Date.utc_today()}T00:00:00Z")
+      DailyToken.changeset(%DailyToken{}, %{quantity: attendee.token_balance, attendee_id: attendee.id, day: date})
     end)
     |> serializable_transaction()
   end

--- a/lib/safira_web/controllers/leaderboard_controller.ex
+++ b/lib/safira_web/controllers/leaderboard_controller.ex
@@ -13,7 +13,10 @@ defmodule SafiraWeb.LeaderboardController do
   def daily(conn, %{"date" => date_params}) do
     case Date.from_iso8601(date_params) do
       {:ok, result} ->
-        attendees = Contest.list_daily_leaderboard(result)
+        board = Contest.list_daily_leaderboard(result)
+        attendees = board 
+                    |> Enum.map(fn a -> %{badge_count: a.badge_count, attendee: Map.put(a.attendee, :token_balance, a.token_count)} end)
+                    |> Enum.map(fn a -> Map.put(a.attendee, :badge_count, a.badge_count) end)
         render(conn, SafiraWeb.LeaderboardView, "index.json", attendees: attendees)
 
       {:error, _error} ->

--- a/priv/repo/migrations/20211118225502_add_daily_token.exs
+++ b/priv/repo/migrations/20211118225502_add_daily_token.exs
@@ -1,0 +1,13 @@
+defmodule Safira.Repo.Migrations.AddDailyToken do
+  use Ecto.Migration
+
+  def change do
+    create table(:daily_tokens) do
+      add :attendee_id, references(:attendees, on_delete: :delete_all, type: :uuid)
+      add :day, :utc_datetime
+      add :quantity, :integer
+
+      timestamps()
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes the daily leaderboard issue.
A new table was created (`daily_tokens`), where the last token balance of each day is stored for every user.
This table is updated everytime the user's token balance is changed.


Closes #229
