### PR TITLE
Added verification to prevent badges for simultaneous activities to be gifted to the same attendee

### DIFF
--- a/data/badges.csv
+++ b/data/badges.csv
@@ -1,4 +1,4 @@
-Badge,Descrição / Como ganhar,Begin,End,Image path,Tipo,Valor (tokens)
+Badge,Descrição / Como ganhar,Begin,End,Begin Badge Period,End Badge Period,Image path,Tipo,Valor (tokens)
 Sessão de abertura,Participa na Sessão de Abertura,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/geral/abertura(FINAL).png,3,20
 Dia 1,Participa no evento no dia 23 de fevereiro,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/geral/dias(FINAL).png,3,20
 Dia 2,Participa no evento no dia 24 de fevereiro,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/geral/dias(2)(FINAL).png,3,20
@@ -20,8 +20,7 @@ Early Bird,Sê uma das primeiras 50 inscrições na SEI,2021-02-23T02:00:00Z,202
 15 empresas,Fala com 15 empresas,2021-02-24T02:00:00Z,2021-02-27T02:00:00Z,data/badges/empresa/empresa(15)(FINAL).png,4,60
 20 empresas,Fala com 20 empresas,2021-02-24T02:00:00Z,2021-02-27T02:00:00Z,data/badges/empresa/empresa(20)(FINAL).png,4,100
 Talk Paulo Dimas,Participa na talk 'The Future of Language: Augmenting AI and Humans',2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/talk(PauloDimas)(FINAL).png,6,25
-Talk Everis,"Participa na talk 'Como escolher o primeiro emprego?'
-",2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/talk(TiagoSantos)(FINAL).png,6,25
+Talk Everis,Participa na talk 'Como escolher o primeiro emprego?',2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/talk(TiagoSantos)(FINAL).png,6,25
 Talk João Oliveira,Participa na talk 'We Can Do It!',2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/talk(JoaoOliveira)(FINAL).png,6,25
 Talk João Dias,Participa na talk 'Developing Tasker - Desafios de um solo Developer',2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/talk(JoaoDias)(FINAL).png,6,25
 Talk Subvisual,Participa na talk '(don’t) use vim',2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/talk/talk(MiguelPalhas)(FINAL).png,6,25
@@ -33,8 +32,7 @@ Talk Francisco Maia,Participa na talk 'STAYAWAY COVID - uma ferramenta de combat
 Talk Gonçalo Silva,Participa na talk 'Developing software remotely and asynchronously',2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/talk/talk(GoncaloSilva)(FINAL).png,6,25
 Talk KPMG,Participa na talk 'The future is KPMG',2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/talk(RuiGoncalves)(FINAL).png,6,25
 Talk Miguel Regedor,Participa na talk '7 Conselhos de um Engenheiro Informático',2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/talk(MiguelRegedor)(FINAL).png,6,25
-Talk André Lago,"Participa na talk 'Como conseguires o teu emprego de sonho na Google'
-",2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/talk(AndreLago)(FINAL).png,6,25
+Talk André Lago,Participa na talk 'Como conseguires o teu emprego de sonho na Google',2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/talk(AndreLago)(FINAL).png,6,25
 The Brave One - Talk Paulo Dimas,Mantém a webcam ligada durante a atividade,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/TheBraveOne(PauloDimas)(FINAL).png,6,5
 The Brave One - Talk Everis,Mantém a webcam ligada durante a atividade,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/TheBraveOne(TiagoSantos)(FINAL).png,6,5
 The Brave One - Talk João Oliveira,Mantém a webcam ligada durante a atividade,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/TheBraveOne(JoaoOliveira)(FINAL).png,6,5

--- a/data/badges.csv
+++ b/data/badges.csv
@@ -1,119 +1,119 @@
-Badge,Descrição / Como ganhar,Begin,End,Begin Badge Period,End Badge Period,Image path,Tipo,Valor (tokens)
-Sessão de abertura,Participa na Sessão de Abertura,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/geral/abertura(FINAL).png,3,20
-Dia 1,Participa no evento no dia 23 de fevereiro,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/geral/dias(FINAL).png,3,20
-Dia 2,Participa no evento no dia 24 de fevereiro,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/geral/dias(2)(FINAL).png,3,20
-Dia 3,Participa no evento no dia 25 de fevereiro,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/geral/dias(3)(FINAL).png,3,20
-Dia 4,Participa no evento no dia 26 de fevereiro,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/dias(4)(FINAL).png,3,20
-Ain't nobody got time fo' that,Participa em todos os dias do evento,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/dias(todos)(FINAL).png,3,50
-Damn son :o,Recebe 115 badges,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/damn(FINAL).png,3,100
-Shopaholic,Faz redeem a todos os itens da loja,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/shopaholic(FINAL).png,3,50
-Talk Aficionado,Participa em todas as talks,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/talkAficionado(FINAL).png,3,50
-Workshop Enthusiast,Participa em 3 workshops,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/workshopenthusiast(FINAL).png,3,50
-Curious George,Participa em todos os pitches,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/curiousgeorge(FINAL).png,3,50
-Curriculum Vitae,Submete o teu Curriculum Vitae,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/curriculumvitae(FINAL).png,3,30
-Acreditação,Entra no Discord da SEI,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/acreditação(FINAL).png,3,5
-SEI Lover,Dá like em todos os posts do Instagram e Facebook da SEI,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/seilover(FINAL).png,3,10
-Influencer,Partilha uma foto da SEI no Facebook e no Instagram,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/influencer(FINAL).png,3,10
-Early Bird,Sê uma das primeiras 50 inscrições na SEI,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/earlyBird(FINAL).png,3,10
-5 empresas,Fala com 5 empresas,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/empresa/empresa(5)(FINAL).png,4,10
-10 empresas,Fala com 10 empresas,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/empresa/empresa(10)(FINAL).png,4,30
-15 empresas,Fala com 15 empresas,2021-02-24T02:00:00Z,2021-02-27T02:00:00Z,data/badges/empresa/empresa(15)(FINAL).png,4,60
-20 empresas,Fala com 20 empresas,2021-02-24T02:00:00Z,2021-02-27T02:00:00Z,data/badges/empresa/empresa(20)(FINAL).png,4,100
-Talk Paulo Dimas,Participa na talk 'The Future of Language: Augmenting AI and Humans',2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/talk(PauloDimas)(FINAL).png,6,25
-Talk Everis,Participa na talk 'Como escolher o primeiro emprego?',2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/talk(TiagoSantos)(FINAL).png,6,25
-Talk João Oliveira,Participa na talk 'We Can Do It!',2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/talk(JoaoOliveira)(FINAL).png,6,25
-Talk João Dias,Participa na talk 'Developing Tasker - Desafios de um solo Developer',2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/talk(JoaoDias)(FINAL).png,6,25
-Talk Subvisual,Participa na talk '(don’t) use vim',2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/talk/talk(MiguelPalhas)(FINAL).png,6,25
-Talk Accenture,Participa na talk 'Deep Dive IoT',2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/talk/talk(AlexandreBrito)(FINAL).png,6,25
-Talk Tiago Carção,Participa na talk 'Sistemas de Larga Escala - O que esperar da indústria',2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/talk/talk(TiagoCarcao)(FINAL).png,6,25
-Talk Juliana Carvalho,Participa na talk 'CV - Check Up',2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/talk/talk(JulianaCarvalho)(FINAL).png,6,25
-Talk GoWithFlow,Participa na talk 'O ecossistema tecnológico da mobilidade sustentável',2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/talk/talk(AndréDias)(FINAL).png,6,25
-Talk Francisco Maia,Participa na talk 'STAYAWAY COVID - uma ferramenta de combate à pandemia',2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/talk/talk(FranciscoMaia)(FINAL).png,6,25
-Talk Gonçalo Silva,Participa na talk 'Developing software remotely and asynchronously',2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/talk/talk(GoncaloSilva)(FINAL).png,6,25
-Talk KPMG,Participa na talk 'The future is KPMG',2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/talk(RuiGoncalves)(FINAL).png,6,25
-Talk Miguel Regedor,Participa na talk '7 Conselhos de um Engenheiro Informático',2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/talk(MiguelRegedor)(FINAL).png,6,25
-Talk André Lago,Participa na talk 'Como conseguires o teu emprego de sonho na Google',2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/talk(AndreLago)(FINAL).png,6,25
-The Brave One - Talk Paulo Dimas,Mantém a webcam ligada durante a atividade,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/TheBraveOne(PauloDimas)(FINAL).png,6,5
-The Brave One - Talk Everis,Mantém a webcam ligada durante a atividade,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/TheBraveOne(TiagoSantos)(FINAL).png,6,5
-The Brave One - Talk João Oliveira,Mantém a webcam ligada durante a atividade,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/TheBraveOne(JoaoOliveira)(FINAL).png,6,5
-The Brave One - Talk João Dias,Mantém a webcam ligada durante a atividade,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/TheBraveOne(JoaoDias)(FINAL).png,6,5
-The Brave One - Talk Subvisual,Mantém a webcam ligada durante a atividade,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/talk/TheBraveOne(MiguelPalhas)(FINAL).png,6,5
-The Brave One - Talk Accenture,Mantém a webcam ligada durante a atividade,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/talk/TheBraveOne(AlexandreBrito)(FINAL).png,6,5
-The Brave One - Talk Tiago Carção,Mantém a webcam ligada durante a atividade,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/talk/TheBraveOne(TiagoCarcao)(FINAL).png,6,5
-The Brave One - Talk Juliana Carvalho,Mantém a webcam ligada durante a atividade,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/talk/TheBraveOne(JulianaCarvalho)(FINAL).png,6,5
-The Brave One - Talk GoWithFlow,Mantém a webcam ligada durante a atividade,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/talk/TheBraveOne(AndréDias)(FINAL).png,6,5
-The Brave One - Talk Francisco Maia,Mantém a webcam ligada durante a atividade,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/talk/TheBraveOne(FranciscoMaia)(FINAL).png,6,5
-The Brave One - Talk Gonçalo Silva,Mantém a webcam ligada durante a atividade,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/talk/TheBraveOne(GonçaloSilva)(FINAL).png,6,5
-The Brave One - Talk KPMG,Mantém a webcam ligada durante a atividade,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/TheBraveOne(RuiGoncalves)(FINAL).png,6,5
-The Brave One - Talk Miguel Regedor,Mantém a webcam ligada durante a atividade,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/TheBraveOne(MiguelRegedor)(FINAL).png,6,5
-The Brave One - Talk André Lago,Mantém a webcam ligada durante a atividade,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/TheBraveOne(AndreLago)(FINAL).png,6,5
-Inquisitor 1,Faz uma pergunta numa talk ou num pitch,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/inquisitor(FINAL).png,6,10
-Inquisitor 2,Faz uma pergunta numa talk ou num pitch,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/inquisitor(2)(FINAL).png,6,10
-Inquisitor 3,Faz uma pergunta numa talk ou num pitch,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/inquisitor(3)(FINAL).png,6,10
-Inquisitor 4,Faz uma pergunta numa talk ou num pitch,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/inquisitor(4)(FINAL).png,6,10
-Inquisitor 5,Faz uma pergunta numa talk ou num pitch,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/inquisitor(5)(FINAL).png,6,10
-Workshop Everis,Participa no workshop da Everis,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/workshop/workshop(Everis)(FINAL).png,7,30
-Workshop Subvisual,Participa no workshop da Subvisual,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/workshop/workshop(Subvisual)(FINAL).png,7,30
-Workshop Critical Software,Participa no workshop da Critical Software,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/workshop/workshop(CriticalSoftware)(FINAL).png,7,30
-Workshop Primavera,Participa no workshop da Primavera,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/workshop/workshop(Primavera)(FINAL).png,7,30
-Workshop Bosch,Participa no workshop da Bosch,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/workshop/workshop(Bosch)(FINAL).png,7,30
-Workshop Accenture,Participa no workshop da Accenture,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/workshop/workshop(Accenture)(FINAL).png,7,30
-The Brave One - Workshop Everis,Mantém a webcam ligada durante a atividade,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/workshop/workshop(theBraveOne)(Everis)(FINAL).png,7,5
-The Brave One - Workshop Subvisual,Mantém a webcam ligada durante a atividade,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/workshop/workshop(theBraveOne)(Subvisual)(FINAL).png,7,5
-The Brave One - Workshop Critical Software,Mantém a webcam ligada durante a atividade,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/workshop/workshop(theBraveOne)(CriticalSoftware)(FINAL).png,7,5
-The Brave One - Workshop Primavera,Mantém a webcam ligada durante a atividade,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/workshop/workshop(theBraveOne)(Primavera)(FINAL).png,7,5
-The Brave One - Workshop Bosch,Mantém a webcam ligada durante a atividade,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/workshop/workshop(theBraveOne)(Bosch)(FINAL).png,7,5
-The Brave One - Workshop Accenture,Mantém a webcam ligada durante a atividade,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/workshop/workshop(theBraveOne)(Accenture)(FINAL).png,7,5
-Pitch Accenture,Participa no pitch,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/pitch/pitch(Accenture)(FINAL).png,9,10
-Pitch Capgemini,Participa no pitch,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/pitch/pitch(Capgemini)(FINAL).png,9,10
-Pitch Ubiwhere,Participa no pitch,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/pitch/pitch(Ubiwhere)(FINAL).png,9,10
-Pitch Vilt,Participa no pitch,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/pitch/pitch(VILT)(FINAL).png,9,10
-Pitch BNP Paribas,Participa no pitch,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/pitch/pitch(BNP)(FINAL).png,9,10
-Pitch OutSystems,Participa no pitch,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/pitch/pitch(Outsystems)(FINAL).png,9,10
-Pitch Eurotux,Participa no pitch,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/pitch/pitch(Eurotux)(FINAL).png,9,10
-Pitch KPMG,Participa no pitch,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/pitch/pitch(KPMG)(FINAL).png,9,10
-Pitch Teleperformance,Participa no pitch,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/pitch/pitch(Teleperformance)(FINAL).png,9,10
-The Brave One - Pitch Accenture,Manter a webcam ligada durante a atividade,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/pitch/pitch(theBraveOne)(Accenture)(FINAL).png,9,5
-The Brave One - Pitch Capgemini,Manter a webcam ligada durante a atividade,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/pitch/pitch(theBraveOne)(Capgemini)(FINAL).png,9,5
-The Brave One - Pitch Ubiwhere,Manter a webcam ligada durante a atividade,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/pitch/pitch(theBraveOne)(Ubiwhere)(FINAL).png,9,5
-The Brave One - Pitch Vilt,Manter a webcam ligada durante a atividade,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/pitch/pitch(theBraveOne)(VILT)(FINAL).png,9,5
-The Brave One - Pitch BNP Paribas,Manter a webcam ligada durante a atividade,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/pitch/pitch(theBraveOne)(BNP)(FINAL).png,9,5
-The Brave One - Pitch OutSystems,Manter a webcam ligada durante a atividade,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/pitch/pitch(theBraveOne)(Outsystems)(FINAL).png,9,5
-The Brave One - Pitch Eurotux,Manter a webcam ligada durante a atividade,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/pitch/pitch(theBraveOne)(Eurotux)(FINAL).png,9,5
-The Brave One - Pitch KPMG,Manter a webcam ligada durante a atividade,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/pitch/pitch(theBraveOne)(KPMG)(FINAL).png,9,5
-The Brave One - Pitch Teleperformance,Manter a webcam ligada durante a atividade,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/pitch/pitch(theBraveOne)(Teleperformance)(FINAL).png,9,5
-Lambe-botas,Manda uma mensagem à organização a dizer que esta é a melhor SEI de sempre!,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/discord/lambebotas(FINAL).png,8,5
-Privacy is dead,Publica (no Discord) uma foto do teu setup/workspace,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/discord/privacy(FINAL).png,8,5
-It's Corona Time,Publica (no Discord) uma foto do que te tem mantido mentalmente são durante esta pandemia (usa a hashtag #itscoronatime),2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/discord/corona(FINAL).png,8,5
-It's Corona Time :(,Publica (no Discord) uma foto do que te tem enlouquecido durante esta pandemia (usa a hashtag #fuckcorona),2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/discord/enlouquecido(FINAL).png,8,5
-Show Off,Publica (no Discord) um print da tua melhor nota,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/discord/showoff(FINAL).png,8,5
-:(,Publica (no Discord) um print da tua pior nota,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/discord/worstnote(FINAL).png,8,5
-Class Clown,Publica (no Discord) uma piada que receba mais de 10 reações (não valem repetidas!),2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/discord/clown(FINAL).png,8,5
-Meme Lord,Publica (no Discord) um meme que receba mais de 20 reações (não valem repetidos!),2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/discord/meme(FINAL).png,8,10
-CTF - Participação,Participa no CTF,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/CTFParticipação(FINAL).png,2,10
-CTF - 1.º lugar,Sê o vencedor do CTF,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/CTF1lugar(FINAL).png,2,50
-CTF - 2.º lugar,Sê o segundo colocado do CTF,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/CTF2lugar(FINAL).png,2,30
-CTF - 3.º lugar,Sê o terceiro colocado do CTF,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/CTF3lugar(FINAL).png,2,20
-I do programming,Inscreve-te na Hackathon,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/idoprogramming(FINAL).png,2,50
-Let Me Take A #Selfie,Participa no desafio de fotografia no Instagram,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/selfie(FINAL).png,2,10
-Google Hashcode - participação,Participa no Google Hashcode (no Hub da SEI),2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/atividades/googlehashcodeParticipação(FINAL).png,2,20
-Google Hashcode - 1.º lugar,Fica em 1.º lugar no Google Hashcode (no Hub da SEI),2021-02-25T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/googlehashcode1lugar(FINAL).png,2,20
-Torneio de Xadrez - participação,Participa no torneiro de xadrez,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/atividades/xadrezParticipação(FINAL).png,2,10
-Torneio de Xadrez - 1.º lugar,Vence o torneiro de xadrez,2021-02-23T02:00:00Z,2021-02-25T02:00:00Z,data/badges/atividades/xadrez1lugar(FINAL).png,2,20
-Torneio de Xadrez - 2.º lugar,Fica em 2º lugar no torneiro de xadrez,2021-02-23T02:00:00Z,2021-02-25T02:00:00Z,data/badges/atividades/xadrez2lugar(FINAL).png,2,10
-Torneio CS:GO - participação,Participa no torneiro de CS:GO,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/atividades/torneioCSGOParticipação(FINAL).png,2,10
-Torneio CS:GO - 1.º lugar,Vence o torneiro de CS:GO,2021-02-23T02:00:00Z,2021-02-25T02:00:00Z,data/badges/atividades/torneioCSGO1lugar(FINAL).png,2,20
-Torneio CS:GO - 2.º lugar,Fica em 2º lugar no torneiro de CS:GO,2021-02-23T02:00:00Z,2021-02-25T02:00:00Z,data/badges/atividades/torneioCSGO2lugar(FINAL).png,2,10
-Discord Master Race - participação,Participa no rally virtual,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/atividades/discordMasterRaceParticipação(FINAL).png,2,10
-Discord Master Race - 1.º lugar,Vence o rally virtual,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/atividades/discordMasterRace1lugar(FINAL).png,2,20
-Discord Social Meeting,Participa no convívio do Discord,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/atividades/discordSocialMeeting(FINAL).png,2,10
-Lucky Bastard 1,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
-Lucky Bastard 2,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
-Lucky Bastard 3,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
-Lucky Bastard 4,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
-Lucky Bastard 5,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
-Lucky Bastard 6,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
-Lucky Bastard 7,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
-Lucky Bastard 8,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
-Lucky Bastard 9,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
-Lucky Bastard 10,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
+Badge,Descrição / Como ganhar,Begin,End,Begin,End,Begin Badge Period,End Badge Period,Image path
+Sessão de abertura,Participa na Sessão de Abertura,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/geral/abertura(FINAL).png,3,20
+Dia 1,Participa no evento no dia 23 de fevereiro,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/geral/dias(FINAL).png,3,20
+Dia 2,Participa no evento no dia 24 de fevereiro,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/geral/dias(2)(FINAL).png,3,20
+Dia 3,Participa no evento no dia 25 de fevereiro,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/geral/dias(3)(FINAL).png,3,20
+Dia 4,Participa no evento no dia 26 de fevereiro,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/dias(4)(FINAL).png,3,20
+Ain't nobody got time fo' that,Participa em todos os dias do evento,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/dias(todos)(FINAL).png,3,50
+Damn son :o,Recebe 115 badges,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/damn(FINAL).png,3,100
+Shopaholic,Faz redeem a todos os itens da loja,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/shopaholic(FINAL).png,3,50
+Talk Aficionado,Participa em todas as talks,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/talkAficionado(FINAL).png,3,50
+Workshop Enthusiast,Participa em 3 workshops,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/workshopenthusiast(FINAL).png,3,50
+Curious George,Participa em todos os pitches,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/curiousgeorge(FINAL).png,3,50
+Curriculum Vitae,Submete o teu Curriculum Vitae,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/curriculumvitae(FINAL).png,3,30
+Acreditação,Entra no Discord da SEI,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/acreditação(FINAL).png,3,5
+SEI Lover,Dá like em todos os posts do Instagram e Facebook da SEI,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/seilover(FINAL).png,3,10
+Influencer,Partilha uma foto da SEI no Facebook e no Instagram,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/influencer(FINAL).png,3,10
+Early Bird,Sê uma das primeiras 50 inscrições na SEI,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/geral/earlyBird(FINAL).png,3,10
+5 empresas,Fala com 5 empresas,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/empresa/empresa(5)(FINAL).png,4,10
+10 empresas,Fala com 10 empresas,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/empresa/empresa(10)(FINAL).png,4,30
+15 empresas,Fala com 15 empresas,2021-02-24T02:00:00Z,2021-02-27T02:00:00Z,2021-02-24T02:00:00Z,2021-02-27T02:00:00Z,data/badges/empresa/empresa(15)(FINAL).png,4,60
+20 empresas,Fala com 20 empresas,2021-02-24T02:00:00Z,2021-02-27T02:00:00Z,2021-02-24T02:00:00Z,2021-02-27T02:00:00Z,data/badges/empresa/empresa(20)(FINAL).png,4,100
+Talk Paulo Dimas,Participa na talk 'The Future of Language: Augmenting AI and Humans',2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/talk(PauloDimas)(FINAL).png,6,25
+Talk Everis,Participa na talk 'Como escolher o primeiro emprego?',2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/talk(TiagoSantos)(FINAL).png,6,25
+Talk João Oliveira,Participa na talk 'We Can Do It!',2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/talk(JoaoOliveira)(FINAL).png,6,25
+Talk João Dias,Participa na talk 'Developing Tasker - Desafios de um solo Developer',2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/talk(JoaoDias)(FINAL).png,6,25
+Talk Subvisual,Participa na talk '(don’t) use vim',2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/talk/talk(MiguelPalhas)(FINAL).png,6,25
+Talk Accenture,Participa na talk 'Deep Dive IoT',2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/talk/talk(AlexandreBrito)(FINAL).png,6,25
+Talk Tiago Carção,Participa na talk 'Sistemas de Larga Escala - O que esperar da indústria',2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/talk/talk(TiagoCarcao)(FINAL).png,6,25
+Talk Juliana Carvalho,Participa na talk 'CV - Check Up',2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/talk/talk(JulianaCarvalho)(FINAL).png,6,25
+Talk GoWithFlow,Participa na talk 'O ecossistema tecnológico da mobilidade sustentável',2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/talk/talk(AndréDias)(FINAL).png,6,25
+Talk Francisco Maia,Participa na talk 'STAYAWAY COVID - uma ferramenta de combate à pandemia',2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/talk/talk(FranciscoMaia)(FINAL).png,6,25
+Talk Gonçalo Silva,Participa na talk 'Developing software remotely and asynchronously',2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/talk/talk(GoncaloSilva)(FINAL).png,6,25
+Talk KPMG,Participa na talk 'The future is KPMG',2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/talk(RuiGoncalves)(FINAL).png,6,25
+Talk Miguel Regedor,Participa na talk '7 Conselhos de um Engenheiro Informático',2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/talk(MiguelRegedor)(FINAL).png,6,25
+Talk André Lago,Participa na talk 'Como conseguires o teu emprego de sonho na Google',2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/talk(AndreLago)(FINAL).png,6,25
+The Brave One - Talk Paulo Dimas,Mantém a webcam ligada durante a atividade,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/TheBraveOne(PauloDimas)(FINAL).png,6,5
+The Brave One - Talk Everis,Mantém a webcam ligada durante a atividade,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/TheBraveOne(TiagoSantos)(FINAL).png,6,5
+The Brave One - Talk João Oliveira,Mantém a webcam ligada durante a atividade,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/TheBraveOne(JoaoOliveira)(FINAL).png,6,5
+The Brave One - Talk João Dias,Mantém a webcam ligada durante a atividade,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/talk/TheBraveOne(JoaoDias)(FINAL).png,6,5
+The Brave One - Talk Subvisual,Mantém a webcam ligada durante a atividade,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/talk/TheBraveOne(MiguelPalhas)(FINAL).png,6,5
+The Brave One - Talk Accenture,Mantém a webcam ligada durante a atividade,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/talk/TheBraveOne(AlexandreBrito)(FINAL).png,6,5
+The Brave One - Talk Tiago Carção,Mantém a webcam ligada durante a atividade,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/talk/TheBraveOne(TiagoCarcao)(FINAL).png,6,5
+The Brave One - Talk Juliana Carvalho,Mantém a webcam ligada durante a atividade,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/talk/TheBraveOne(JulianaCarvalho)(FINAL).png,6,5
+The Brave One - Talk GoWithFlow,Mantém a webcam ligada durante a atividade,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/talk/TheBraveOne(AndréDias)(FINAL).png,6,5
+The Brave One - Talk Francisco Maia,Mantém a webcam ligada durante a atividade,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/talk/TheBraveOne(FranciscoMaia)(FINAL).png,6,5
+The Brave One - Talk Gonçalo Silva,Mantém a webcam ligada durante a atividade,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/talk/TheBraveOne(GonçaloSilva)(FINAL).png,6,5
+The Brave One - Talk KPMG,Mantém a webcam ligada durante a atividade,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/TheBraveOne(RuiGoncalves)(FINAL).png,6,5
+The Brave One - Talk Miguel Regedor,Mantém a webcam ligada durante a atividade,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/TheBraveOne(MiguelRegedor)(FINAL).png,6,5
+The Brave One - Talk André Lago,Mantém a webcam ligada durante a atividade,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/TheBraveOne(AndreLago)(FINAL).png,6,5
+Inquisitor 1,Faz uma pergunta numa talk ou num pitch,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/inquisitor(FINAL).png,6,10
+Inquisitor 2,Faz uma pergunta numa talk ou num pitch,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/inquisitor(2)(FINAL).png,6,10
+Inquisitor 3,Faz uma pergunta numa talk ou num pitch,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/inquisitor(3)(FINAL).png,6,10
+Inquisitor 4,Faz uma pergunta numa talk ou num pitch,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/inquisitor(4)(FINAL).png,6,10
+Inquisitor 5,Faz uma pergunta numa talk ou num pitch,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/talk/inquisitor(5)(FINAL).png,6,10
+Workshop Everis,Participa no workshop da Everis,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/workshop/workshop(Everis)(FINAL).png,7,30
+Workshop Subvisual,Participa no workshop da Subvisual,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/workshop/workshop(Subvisual)(FINAL).png,7,30
+Workshop Critical Software,Participa no workshop da Critical Software,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/workshop/workshop(CriticalSoftware)(FINAL).png,7,30
+Workshop Primavera,Participa no workshop da Primavera,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/workshop/workshop(Primavera)(FINAL).png,7,30
+Workshop Bosch,Participa no workshop da Bosch,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/workshop/workshop(Bosch)(FINAL).png,7,30
+Workshop Accenture,Participa no workshop da Accenture,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/workshop/workshop(Accenture)(FINAL).png,7,30
+The Brave One - Workshop Everis,Mantém a webcam ligada durante a atividade,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/workshop/workshop(theBraveOne)(Everis)(FINAL).png,7,5
+The Brave One - Workshop Subvisual,Mantém a webcam ligada durante a atividade,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/workshop/workshop(theBraveOne)(Subvisual)(FINAL).png,7,5
+The Brave One - Workshop Critical Software,Mantém a webcam ligada durante a atividade,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/workshop/workshop(theBraveOne)(CriticalSoftware)(FINAL).png,7,5
+The Brave One - Workshop Primavera,Mantém a webcam ligada durante a atividade,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/workshop/workshop(theBraveOne)(Primavera)(FINAL).png,7,5
+The Brave One - Workshop Bosch,Mantém a webcam ligada durante a atividade,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/workshop/workshop(theBraveOne)(Bosch)(FINAL).png,7,5
+The Brave One - Workshop Accenture,Mantém a webcam ligada durante a atividade,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/workshop/workshop(theBraveOne)(Accenture)(FINAL).png,7,5
+Pitch Accenture,Participa no pitch,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/pitch/pitch(Accenture)(FINAL).png,9,10
+Pitch Capgemini,Participa no pitch,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/pitch/pitch(Capgemini)(FINAL).png,9,10
+Pitch Ubiwhere,Participa no pitch,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/pitch/pitch(Ubiwhere)(FINAL).png,9,10
+Pitch Vilt,Participa no pitch,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/pitch/pitch(VILT)(FINAL).png,9,10
+Pitch BNP Paribas,Participa no pitch,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/pitch/pitch(BNP)(FINAL).png,9,10
+Pitch OutSystems,Participa no pitch,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/pitch/pitch(Outsystems)(FINAL).png,9,10
+Pitch Eurotux,Participa no pitch,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/pitch/pitch(Eurotux)(FINAL).png,9,10
+Pitch KPMG,Participa no pitch,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/pitch/pitch(KPMG)(FINAL).png,9,10
+Pitch Teleperformance,Participa no pitch,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/pitch/pitch(Teleperformance)(FINAL).png,9,10
+The Brave One - Pitch Accenture,Manter a webcam ligada durante a atividade,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/pitch/pitch(theBraveOne)(Accenture)(FINAL).png,9,5
+The Brave One - Pitch Capgemini,Manter a webcam ligada durante a atividade,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/pitch/pitch(theBraveOne)(Capgemini)(FINAL).png,9,5
+The Brave One - Pitch Ubiwhere,Manter a webcam ligada durante a atividade,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/pitch/pitch(theBraveOne)(Ubiwhere)(FINAL).png,9,5
+The Brave One - Pitch Vilt,Manter a webcam ligada durante a atividade,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/pitch/pitch(theBraveOne)(VILT)(FINAL).png,9,5
+The Brave One - Pitch BNP Paribas,Manter a webcam ligada durante a atividade,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/pitch/pitch(theBraveOne)(BNP)(FINAL).png,9,5
+The Brave One - Pitch OutSystems,Manter a webcam ligada durante a atividade,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/pitch/pitch(theBraveOne)(Outsystems)(FINAL).png,9,5
+The Brave One - Pitch Eurotux,Manter a webcam ligada durante a atividade,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/pitch/pitch(theBraveOne)(Eurotux)(FINAL).png,9,5
+The Brave One - Pitch KPMG,Manter a webcam ligada durante a atividade,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/pitch/pitch(theBraveOne)(KPMG)(FINAL).png,9,5
+The Brave One - Pitch Teleperformance,Manter a webcam ligada durante a atividade,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/pitch/pitch(theBraveOne)(Teleperformance)(FINAL).png,9,5
+Lambe-botas,Manda uma mensagem à organização a dizer que esta é a melhor SEI de sempre!,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/discord/lambebotas(FINAL).png,8,5
+Privacy is dead,Publica (no Discord) uma foto do teu setup/workspace,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/discord/privacy(FINAL).png,8,5
+It's Corona Time,Publica (no Discord) uma foto do que te tem mantido mentalmente são durante esta pandemia (usa a hashtag #itscoronatime),2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/discord/corona(FINAL).png,8,5
+It's Corona Time :(,Publica (no Discord) uma foto do que te tem enlouquecido durante esta pandemia (usa a hashtag #fuckcorona),2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/discord/enlouquecido(FINAL).png,8,5
+Show Off,Publica (no Discord) um print da tua melhor nota,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/discord/showoff(FINAL).png,8,5
+:(,Publica (no Discord) um print da tua pior nota,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/discord/worstnote(FINAL).png,8,5
+Class Clown,Publica (no Discord) uma piada que receba mais de 10 reações (não valem repetidas!),2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/discord/clown(FINAL).png,8,5
+Meme Lord,Publica (no Discord) um meme que receba mais de 20 reações (não valem repetidos!),2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/discord/meme(FINAL).png,8,10
+CTF - Participação,Participa no CTF,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/CTFParticipação(FINAL).png,2,10
+CTF - 1.º lugar,Sê o vencedor do CTF,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/CTF1lugar(FINAL).png,2,50
+CTF - 2.º lugar,Sê o segundo colocado do CTF,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/CTF2lugar(FINAL).png,2,30
+CTF - 3.º lugar,Sê o terceiro colocado do CTF,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,2021-02-26T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/CTF3lugar(FINAL).png,2,20
+I do programming,Inscreve-te na Hackathon,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/idoprogramming(FINAL).png,2,50
+Let Me Take A #Selfie,Participa no desafio de fotografia no Instagram,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/selfie(FINAL).png,2,10
+Google Hashcode - participação,Participa no Google Hashcode (no Hub da SEI),2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/atividades/googlehashcodeParticipação(FINAL).png,2,20
+Google Hashcode - 1.º lugar,Fica em 1.º lugar no Google Hashcode (no Hub da SEI),2021-02-25T02:00:00Z,2021-02-27T02:00:00Z,2021-02-25T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/googlehashcode1lugar(FINAL).png,2,20
+Torneio de Xadrez - participação,Participa no torneiro de xadrez,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/atividades/xadrezParticipação(FINAL).png,2,10
+Torneio de Xadrez - 1.º lugar,Vence o torneiro de xadrez,2021-02-23T02:00:00Z,2021-02-25T02:00:00Z,2021-02-23T02:00:00Z,2021-02-25T02:00:00Z,data/badges/atividades/xadrez1lugar(FINAL).png,2,20
+Torneio de Xadrez - 2.º lugar,Fica em 2º lugar no torneiro de xadrez,2021-02-23T02:00:00Z,2021-02-25T02:00:00Z,2021-02-23T02:00:00Z,2021-02-25T02:00:00Z,data/badges/atividades/xadrez2lugar(FINAL).png,2,10
+Torneio CS:GO - participação,Participa no torneiro de CS:GO,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,2021-02-23T02:00:00Z,2021-02-24T02:00:00Z,data/badges/atividades/torneioCSGOParticipação(FINAL).png,2,10
+Torneio CS:GO - 1.º lugar,Vence o torneiro de CS:GO,2021-02-23T02:00:00Z,2021-02-25T02:00:00Z,2021-02-23T02:00:00Z,2021-02-25T02:00:00Z,data/badges/atividades/torneioCSGO1lugar(FINAL).png,2,20
+Torneio CS:GO - 2.º lugar,Fica em 2º lugar no torneiro de CS:GO,2021-02-23T02:00:00Z,2021-02-25T02:00:00Z,2021-02-23T02:00:00Z,2021-02-25T02:00:00Z,data/badges/atividades/torneioCSGO2lugar(FINAL).png,2,10
+Discord Master Race - participação,Participa no rally virtual,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/atividades/discordMasterRaceParticipação(FINAL).png,2,10
+Discord Master Race - 1.º lugar,Vence o rally virtual,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,2021-02-24T02:00:00Z,2021-02-25T02:00:00Z,data/badges/atividades/discordMasterRace1lugar(FINAL).png,2,20
+Discord Social Meeting,Participa no convívio do Discord,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,2021-02-25T02:00:00Z,2021-02-26T02:00:00Z,data/badges/atividades/discordSocialMeeting(FINAL).png,2,10
+Lucky Bastard 1,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
+Lucky Bastard 2,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
+Lucky Bastard 3,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
+Lucky Bastard 4,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
+Lucky Bastard 5,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
+Lucky Bastard 6,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
+Lucky Bastard 7,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
+Lucky Bastard 8,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
+Lucky Bastard 9,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0
+Lucky Bastard 10,Joga na 'Spin the Wheel' para te habilitares a receber este badge,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,2021-02-23T02:00:00Z,2021-02-27T02:00:00Z,data/badges/atividades/luckybastard(FINAL).png,2,0

--- a/lib/mix/tasks/gen.badges.ex
+++ b/lib/mix/tasks/gen.badges.ex
@@ -52,16 +52,30 @@ defmodule Mix.Tasks.Gen.Badges do
     path
     |> File.stream!()
     |> CSV.parse_stream()
-    |> Enum.map(fn [name, description, begin_time, end_time, image_path, type, tokens] ->
+    |> Enum.map(fn [
+                     name,
+                     description,
+                     begin_time,
+                     end_time,
+                     begin_badge,
+                     end_badge,
+                     image_path,
+                     type,
+                     tokens
+                   ] ->
       {:ok, begin_datetime, _} = DateTime.from_iso8601(begin_time)
       {:ok, end_datetime, _} = DateTime.from_iso8601(end_time)
+      {:ok, begin_badge_datetime, _} = DateTime.from_iso8601(begin_badge)
+      {:ok, end_badge_datetime, _} = DateTime.from_iso8601(end_badge)
 
       {
         %{
           name: name,
           description: description,
-          begin: begin_datetime,
-          end: end_datetime,
+          begin_activity: begin_datetime,
+          end_activity: end_datetime,
+          begin_badge: begin_badge_datetime,
+          end_badge: end_badge_datetime,
           type: String.to_integer(type),
           tokens: String.to_integer(tokens)
         },

--- a/lib/mix/tasks/gen.badges.ex
+++ b/lib/mix/tasks/gen.badges.ex
@@ -72,8 +72,8 @@ defmodule Mix.Tasks.Gen.Badges do
         %{
           name: name,
           description: description,
-          begin_activity: begin_datetime,
-          end_activity: end_datetime,
+          begin: begin_datetime,
+          end: end_datetime,
           begin_badge: begin_badge_datetime,
           end_badge: end_badge_datetime,
           type: String.to_integer(type),

--- a/lib/safira/contest/badge.ex
+++ b/lib/safira/contest/badge.ex
@@ -11,8 +11,8 @@ defmodule Safira.Contest.Badge do
     field(:name, :string)
     field(:description, :string)
 
-    field(:begin_activity, :utc_datetime)
-    field(:end_activity, :utc_datetime)
+    field(:begin, :utc_datetime)
+    field(:end, :utc_datetime)
     field(:begin_badge, :utc_datetime)
     field(:end_badge, :utc_datetime)
 
@@ -34,8 +34,8 @@ defmodule Safira.Contest.Badge do
     |> cast(attrs, [
       :name,
       :description,
-      :begin_activity,
-      :end_activity,
+      :begin,
+      :end,
       :begin_badge,
       :end_badge,
       :type,
@@ -45,8 +45,8 @@ defmodule Safira.Contest.Badge do
     |> validate_required([
       :name,
       :description,
-      :begin_activity,
-      :end_activity,
+      :begin,
+      :end,
       :begin_badge,
       :end_badge,
       :type,
@@ -61,8 +61,8 @@ defmodule Safira.Contest.Badge do
   def admin_changeset(badge, attrs) do
     badge
     |> cast(attrs, [
-      :begin_activity,
-      :end_activity,
+      :begin,
+      :end,
       :begin_badge,
       :end_badge,
       :name,
@@ -72,8 +72,8 @@ defmodule Safira.Contest.Badge do
     ])
     |> cast_attachments(attrs, [:avatar])
     |> validate_required([
-      :begin_activity,
-      :end_activity,
+      :begin,
+      :end,
       :begin_badge,
       :end_badge,
       :name,
@@ -87,20 +87,20 @@ defmodule Safira.Contest.Badge do
   end
 
   defp validate_time(changeset) do
-    {_, begin_activity} = fetch_field(changeset, :begin_activity)
-    {_, end_activity} = fetch_field(changeset, :end_activity)
+    {_, begin_time} = fetch_field(changeset, :begin)
+    {_, end_time} = fetch_field(changeset, :end)
     {_, begin_badge} = fetch_field(changeset, :begin_badge)
     {_, end_badge} = fetch_field(changeset, :end_badge)
 
     cond do
-      case DateTime.compare(begin_activity, end_activity)
-        and Datetime.compare(begin_badge,end_badge) do
-          :lt -> changeset
-          _ -> add_error(changeset, :begin, "Begin time can't be after end time")
-        end
+      DateTime.compare(begin_time, end_time) != :gt ->
+        add_error(changeset, :begin, "Activity time Invalid")
 
-      _ ->
-        add_error(changeset, :begin, "Times not correct format")
+      Datetime.compare(begin_badge, end_badge) != :gt ->
+        add_error(changeset, :begin_badge, "Badge-gifting time Invalid")
+
+      true ->
+        changeset
     end
   end
 end

--- a/lib/safira/contest/badge.ex
+++ b/lib/safira/contest/badge.ex
@@ -8,18 +8,22 @@ defmodule Safira.Contest.Badge do
   alias Safira.Accounts.Attendee
 
   schema "badges" do
-    field :begin, :utc_datetime
-    field :end, :utc_datetime
-    field :name, :string
-    field :description, :string
-    field :avatar, Safira.Avatar.Type
-    #%{verificações: 0, secret: 1, desafios: 2, geral: 3, empresas: 4, oradores: 5, talks: 6, workshops: 7, discord: 8, pitches: 9}
-    field :type, :integer
-    field :tokens, :integer
+    field(:name, :string)
+    field(:description, :string)
 
+    field(:begin_activity, :utc_datetime)
+    field(:end_activity, :utc_datetime)
+    field(:begin_badge, :utc_datetime)
+    field(:end_badge, :utc_datetime)
 
-    has_many :referrals, Referral
-    many_to_many :attendees, Attendee, join_through: Redeem
+    field(:avatar, Safira.Avatar.Type)
+
+    # %{verificações: 0, secret: 1, desafios: 2, geral: 3, empresas: 4, oradores: 5, talks: 6, workshops: 7, discord: 8, pitches: 9}
+    field(:type, :integer)
+    field(:tokens, :integer)
+
+    has_many(:referrals, Referral)
+    many_to_many(:attendees, Attendee, join_through: Redeem)
 
     timestamps()
   end
@@ -27,9 +31,27 @@ defmodule Safira.Contest.Badge do
   @doc false
   def changeset(badge, attrs) do
     badge
-    |> cast(attrs, [:name, :description, :begin, :end, :type, :tokens])
+    |> cast(attrs, [
+      :name,
+      :description,
+      :begin_activity,
+      :end_activity,
+      :begin_badge,
+      :end_badge,
+      :type,
+      :tokens
+    ])
     |> cast_attachments(attrs, [:avatar])
-    |> validate_required([:name, :description, :begin, :end, :type, :tokens])
+    |> validate_required([
+      :name,
+      :description,
+      :begin_activity,
+      :end_activity,
+      :begin_badge,
+      :end_badge,
+      :type,
+      :tokens
+    ])
     |> validate_length(:name, min: 1, max: 255)
     |> validate_length(:description, min: 1, max: 1000)
     |> validate_time
@@ -38,25 +60,47 @@ defmodule Safira.Contest.Badge do
   @doc false
   def admin_changeset(badge, attrs) do
     badge
-    |> cast(attrs, [:begin, :end, :name, :description, :type, :tokens])
+    |> cast(attrs, [
+      :begin_activity,
+      :end_activity,
+      :begin_badge,
+      :end_badge,
+      :name,
+      :description,
+      :type,
+      :tokens
+    ])
     |> cast_attachments(attrs, [:avatar])
-    |> validate_required([:begin, :end, :name, :description, :type, :tokens])
+    |> validate_required([
+      :begin_activity,
+      :end_activity,
+      :begin_badge,
+      :end_badge,
+      :name,
+      :description,
+      :type,
+      :tokens
+    ])
     |> validate_length(:name, min: 1, max: 255)
     |> validate_length(:description, min: 1, max: 1000)
     |> validate_time
   end
 
   defp validate_time(changeset) do
-    {_, begin_time} = fetch_field(changeset, :begin)
-    {_, end_time} = fetch_field(changeset, :end)
+    {_, begin_activity} = fetch_field(changeset, :begin_activity)
+    {_, end_activity} = fetch_field(changeset, :end_activity)
+    {_, begin_badge} = fetch_field(changeset, :begin_badge)
+    {_, end_badge} = fetch_field(changeset, :end_badge)
 
-    case !!begin_time and !!end_time do
-      true ->
-        case DateTime.compare(begin_time, end_time) do
+    cond do
+      case DateTime.compare(begin_activity, end_activity)
+        and Datetime.compare(begin_badge,end_badge) do
           :lt -> changeset
-          _ -> add_error(changeset, :begin, "Begin time can't be after end time" )
+          _ -> add_error(changeset, :begin, "Begin time can't be after end time")
         end
-      _ -> add_error(changeset, :begin, "Times not correct format" )
+
+      _ ->
+        add_error(changeset, :begin, "Times not correct format")
     end
   end
 end

--- a/lib/safira/contest/redeem.ex
+++ b/lib/safira/contest/redeem.ex
@@ -30,11 +30,11 @@ defmodule Safira.Contest.Redeem do
     curr = Datetime.utc_now()
 
     cond do
-      Datetime.compare(curr, badge.start) == :lt ->
-        add_error(changeset, :begin, "Badge cannot be redeemed before the activity")
+      Datetime.compare(curr, badge.start_badge) == :lt ->
+        add_error(changeset, :begin_badge, "Can't redeem Badge before badge-gifting period")
 
-      Datetime.compare(curr, badge.end) == :gt ->
-        add_error(changeset, :end, "Badge cannot be redeemed after the activity")
+      Datetime.compare(curr, badge.end_badge) == :gt ->
+        add_error(changeset, :end_badge, "Can't redeem Badge before badge-gifting period")
 
       true ->
         changeset

--- a/lib/safira/contest/redeem.ex
+++ b/lib/safira/contest/redeem.ex
@@ -43,9 +43,16 @@ defmodule Safira.Contest.Redeem do
     end
   end
 
+  # workshops, pitches, talks
+  def is_unique_type(type) do
+    type == 6 or type == 7 or type == 9
+  end
+
+  # verifica se os badges sao simultaneos e algum deles é um workshop
   def coincidental(badge_a, badge_b) do
     Datetime.compare(badge_a.begin, badge_b.end) == :lt and
-      Datetime.compare(badge_b.begin, badge_a.end) == :lt
+      Datetime.compare(badge_b.begin, badge_a.end) == :lt and
+      is_unique_type(badge_a.type) and is_unique_type(badge_b.type)
   end
 
   def is_within_period(changeset) do

--- a/priv/repo/migrations/20220119232208_add_begin_end_badges.exs
+++ b/priv/repo/migrations/20220119232208_add_begin_end_badges.exs
@@ -1,0 +1,9 @@
+defmodule Safira.Repo.Migrations.AddBeginEndBadges do
+  use Ecto.Migration
+
+  def change do
+    alter table(:badges) do
+      add :begin_badge, :utc_datetime, null: false
+      add :end_badge, :utc_datetime, null: false
+  end
+end


### PR DESCRIPTION
- Added fields to badges.csv to keep track of badge-gifting period, apart from the period of the activity itself. Made corresponding changes to parsing and badge structure
- Added migration for add and begin end badges
- Updated badges.csv to reflect te changes made on badge format
- Added verification before gifting badge, to check whether the attendee already has a badge of an activity for that time and date
- Changed verification to allow simultaneous badges for coincidental activities which aren't workshops, pitches or talks
