### PR TITLE
Fix some roulette tests

### DIFF
--- a/test/safira/roulette_test.exs
+++ b/test/safira/roulette_test.exs
@@ -6,7 +6,7 @@ defmodule Safira.RouletteTest do
   describe "prizes" do
     alias Safira.Roulette.Prize
 
-    @valid_attrs %{max_amount_per_attendee: 10, name: "some name", probability: 0.42, stock: 40}
+    @valid_attrs %{max_amount_per_attendee: 10, name: "some name", probability: 0.42, stock: 40, is_redeemable: true}
     @update_attrs %{
       max_amount_per_attendee: 51,
       name: "some updated name",


### PR DESCRIPTION
As you can see from here, `is_redeemable` is a required parameter:
```elixir
def changeset(prize, attrs) do
  ...
  |> validate_required([:name, :stock, :max_amount_per_attendee, :probability, :is_redeemable])
  ...
end
  ```