### PR TITLE
Add endpoint for a company to download the CVs of it's attendees

### DIFF
--- a/lib/safira/web/uploaders/cv.ex
+++ b/lib/safira/web/uploaders/cv.ex
@@ -53,6 +53,7 @@ defmodule Safira.CV do
   def storage_dir(_version, {_file, scope}) do
     storage_dir(scope)
   end
+
   def s3_object_headers(version, {file, scope}) do
     [content_type: MIME.from_path(file.file_name)]
   end

--- a/lib/safira/web/uploaders/cv.ex
+++ b/lib/safira/web/uploaders/cv.ex
@@ -46,17 +46,13 @@ defmodule Safira.CV do
     version
   end
 
-  def storage_dir(version, {file, scope}) do
-    struct =
-      scope.__struct__
-      |> Kernel.to_string()
-      |> String.split(".")
-      |> List.last()
-      |> String.downcase()
-
-    "uploads/#{struct}/cvs/#{scope.id}"
+  def storage_dir(scope) do
+    "uploads/attendee/cvs/" <> "#{scope.id}"
   end
 
+  def storage_dir(_version, {_file, scope}) do
+    storage_dir(scope)
+  end
   def s3_object_headers(version, {file, scope}) do
     [content_type: MIME.from_path(file.file_name)]
   end

--- a/lib/safira_web/controllers/cv_controller.ex
+++ b/lib/safira_web/controllers/cv_controller.ex
@@ -1,0 +1,56 @@
+defmodule SafiraWeb.CVController do
+  use SafiraWeb, :controller
+
+  alias Safira.Accounts
+
+  alias Safira.CV
+
+  action_fallback SafiraWeb.FallbackController
+
+  def company_cvs(conn, %{"id" => company_id}) do
+    curr_user = Accounts.get_user(conn)
+
+    curr_company_id =
+      curr_user
+      |> Map.get(:company)
+      |> case do
+        nil -> nil
+        company -> Map.get(company, :id)
+      end
+
+    company = Accounts.get_company!(company_id)
+
+    if Accounts.is_admin(conn) or curr_company_id == company.id do
+      attendees_cvs =
+        Accounts.list_company_attendees(company_id)
+        |> Enum.filter(fn x -> x.cv != nil end)
+        |> Enum.map(fn x -> {x.nickname, CV.storage_dir(x)} end)
+        |> Enum.map(fn {nickname, storage_dir} ->
+          {nickname,
+           File.ls!(storage_dir)
+           |> List.first() # should never return nil because we enure the attendee has a CV
+           |> (fn file_name -> Path.join(storage_dir, file_name) end).()
+           |> File.read()}
+        end)
+        |> Enum.filter(fn {_, {s, _}} -> s == :ok end)
+        |> Enum.map(fn {nickname, {_, data}} ->
+          {(nickname <> ".pdf")
+           |> String.to_charlist(), data}
+        end)
+
+      {:ok, {zip_filename, zip_bin}} = :zip.create('cvs.zip', attendees_cvs, [:memory])
+
+      conn
+      |> put_status(:ok)
+      |> send_download({:binary, zip_bin}, [{:filename, "#{zip_filename}"}])
+    else
+      conn
+      |> put_status(:unauthorized)
+      |> json(%{
+        error: "The CVs of a company's attendees can only be accessed by the company or by the admin",
+        company_id: company_id,
+        user: curr_company_id
+      })
+    end
+  end
+end

--- a/lib/safira_web/controllers/cv_controller.ex
+++ b/lib/safira_web/controllers/cv_controller.ex
@@ -28,7 +28,8 @@ defmodule SafiraWeb.CVController do
         |> Enum.map(fn {nickname, storage_dir} ->
           {nickname,
            File.ls!(storage_dir)
-           |> List.first() # should never return nil because we enure the attendee has a CV
+           # should never return nil because we enure the attendee has a CV
+           |> List.first()
            |> (fn file_name -> Path.join(storage_dir, file_name) end).()
            |> File.read()}
         end)
@@ -47,7 +48,8 @@ defmodule SafiraWeb.CVController do
       conn
       |> put_status(:unauthorized)
       |> json(%{
-        error: "The CVs of a company's attendees can only be accessed by the company or by the admin",
+        error:
+          "The CVs of a company's attendees can only be accessed by the company or by the admin",
         company_id: company_id,
         user: curr_company_id
       })

--- a/lib/safira_web/router.ex
+++ b/lib/safira_web/router.ex
@@ -74,6 +74,7 @@ defmodule SafiraWeb.Router do
       resources "/roulette/prizes", PrizeController, only: [:index, :show]
 
       get "/company/attendees/:id", CompanyController, :company_attendees
+      get "/company/attendees/cvs/:id", CVController, :company_cvs
     end
   end
 

--- a/test/safira_web/controllers/cv_controller_test.exs
+++ b/test/safira_web/controllers/cv_controller_test.exs
@@ -1,0 +1,110 @@
+defmodule SafiraWeb.CVControllerTest do
+  use SafiraWeb.ConnCase
+
+  alias Safira.CV
+  alias SafiraWeb.CVController
+  alias Safira.Accounts
+
+  setup %{conn: conn} do
+    badge = insert(:badge)
+
+    user_company = create_user_strategy(:user)
+    company = insert(:company, user: user_company, badge: badge)
+
+    user_attendee_with_badge = create_user_strategy(:user)
+    attendee_with_badge = insert(:attendee, user: user_attendee_with_badge)
+    insert(:redeem, attendee: attendee_with_badge, badge: badge)
+
+    user_attendee_without_badge = create_user_strategy(:user)
+    attendee_without_badge = insert(:attendee, user: user_attendee_without_badge)
+
+    cv = %Plug.Upload{
+      filename: "ValidCV.pdf",
+      path: "priv/fake/ValidCV.pdf",
+      content_type: "application/pdf"
+    }
+
+    %{conn: conn1, user: _user} = api_authenticate(user_attendee_with_badge)
+
+    conn1
+    |> put(Routes.attendee_path(conn, :update, attendee_with_badge.id), %{
+      "id" => attendee_with_badge.id,
+      "attendee" => %{"cv" => cv}
+    })
+
+    %{conn: conn2, user: _user} = api_authenticate(user_attendee_without_badge)
+
+    conn2
+    |> put(Routes.attendee_path(conn, :update, attendee_without_badge.id), %{
+      "id" => attendee_without_badge.id,
+      "attendee" => %{"cv" => cv}
+    })
+
+    {:ok,
+     conn: put_req_header(conn, "accept", "application/json"),
+     user_company: user_company,
+     company: company,
+     attendee_with_badge: attendee_with_badge}
+  end
+
+  describe "company_cvs" do
+    test "company downloads the CVs of it's own attendees", %{
+      user_company: user_company,
+      company: company,
+      attendee_with_badge: attendee
+    } do
+      %{conn: conn, user: _user} = api_authenticate(user_company)
+
+      conn =
+        conn
+        |> get(Routes.cv_path(conn, :company_cvs, company.id))
+
+      assert response(conn, 200)
+
+      assert {:ok, files} = :zip.extract(conn.resp_body, [:memory])
+
+      assert Kernel.length(files) == 1
+
+      assert List.first(files) |> Kernel.elem(0) ==
+               (attendee.nickname <> ".pdf") |> String.to_charlist()
+    end
+
+    test "admin downloads the CVs of a company's attendees", %{
+      company: company,
+      attendee_with_badge: attendee
+    } do
+      user = create_user_strategy(:user)
+      admin = insert(:manager, user: user, is_admin: true)
+
+      %{conn: conn, user: _user} = api_authenticate(user)
+
+      conn =
+        conn
+        |> get(Routes.cv_path(conn, :company_cvs, company.id))
+
+      assert response(conn, 200)
+
+      assert {:ok, files} = :zip.extract(conn.resp_body, [:memory])
+
+      assert Kernel.length(files) == 1
+
+      assert List.first(files) |> Kernel.elem(0) ==
+               (attendee.nickname <> ".pdf") |> String.to_charlist()
+    end
+
+    test "company downloads the CVs of other company's attendees", %{
+      user_company: user_company,
+      company: company
+    } do
+      other_company = insert(:company)
+
+      %{conn: conn, user: _user} = api_authenticate(user_company)
+
+      conn =
+        conn
+        |> get(Routes.cv_path(conn, :company_cvs, other_company.id))
+
+      assert response(conn, 401)
+    end
+  end
+end


### PR DESCRIPTION
The generated zip file contains the CVs of the attendees of the company on the root.
Every CV is a `pdf` named after the attendee's nickname (which should be unique) (e.g. `zer0.pdf`)

This endpoint should only be accessible by the company itself or by an admin.