### PR TITLE
fix: check wheel prize validity

### DIFF
--- a/data/wheel.csv
+++ b/data/wheel.csv
@@ -8,7 +8,7 @@ JBL GO Essential,1,5,0.0015,yes,data/roulette/jbl.png
 Gift Card 20€,1,5,0.0015,yes,data/roulette/cartao.png
 Gift Card 10€,1,10,0.0075,yes,data/roulette/cartao.png
 Chocolates,1,100,0.019,yes,data/roulette/chocolates.png
-Lucky Bastard,10,999999,0.1,no,data/roulette/luckybastard.png
+Lucky Bastard,1,999999,0.1,no,data/roulette/luckybastard.png
 Tokens,999999,999999,0.07,no,data/roulette/tokens.png
 1 entrada no jantar empresarial,1,1,0.0145,no,data/roulette/dinner.png
 Entradas para o sorteio final,999999,999999,0.17,no,data/roulette/entries.png


### PR DESCRIPTION
Sometimes an attendee would roll the wheel and get a prize for which they had already received the maximum amount. This would cause an error, and the attendee would lose the tokens spent on the spin.
Now the wheel checks if the user has already received the maximum amount of the prize, and if so, spins again.