### PR TITLE
feat: staff curriculum upload

### DIFF
--- a/lib/mix/tasks/gen.staffs.ex
+++ b/lib/mix/tasks/gen.staffs.ex
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.Gen.Staffs do
         "password_confirmation" => password
       }
 
-      Accounts.create_staff(%{"user" => user})
+      Accounts.create_staff(%{"user" => user, "nickname" => "staff#{man_num() + 1}"})
 
       IO.puts("#{email}:#{password}")
     end)

--- a/lib/mix/tasks/gen.staffs_from_csv.ex
+++ b/lib/mix/tasks/gen.staffs_from_csv.ex
@@ -90,7 +90,11 @@ defmodule Mix.Tasks.Gen.StaffsFromCsv do
         "password_confirmation" => password
       }
 
-      Accounts.create_staff(%{"user" => user, "is_admin" => convert!(user_csv_entry.admin)})
+      Accounts.create_staff(%{
+        "user" => user,
+        "is_admin" => convert!(user_csv_entry.admin),
+        "nickname" => user_csv_entry.username
+      })
 
       IO.puts("#{email}:#{password}")
     end)

--- a/lib/safira/accounts/accounts.ex
+++ b/lib/safira/accounts/accounts.ex
@@ -180,6 +180,12 @@ defmodule Safira.Accounts do
     |> Repo.update()
   end
 
+  def update_staff_cv(%Staff{} = staff, attrs) do
+    staff
+    |> Staff.update_changeset_cv(attrs)
+    |> Repo.update()
+  end
+
   def delete_staff(%Staff{} = staff) do
     Repo.delete(staff)
   end

--- a/lib/safira/accounts/staff.ex
+++ b/lib/safira/accounts/staff.ex
@@ -4,6 +4,7 @@ defmodule Safira.Accounts.Staff do
   deliver them prizes they win throughout the event
   """
   use Ecto.Schema
+  use Arc.Ecto.Schema
   import Ecto.Changeset
 
   alias Safira.Accounts.User
@@ -12,6 +13,8 @@ defmodule Safira.Accounts.Staff do
   schema "staffs" do
     field :active, :boolean, default: true
     field :is_admin, :boolean, default: false
+    field :nickname, :string
+    field :cv, Safira.CV.Type
 
     belongs_to :user, User
     has_many :redeems, Redeem
@@ -21,8 +24,14 @@ defmodule Safira.Accounts.Staff do
 
   def changeset(staff, attrs) do
     staff
-    |> cast(attrs, [:active, :is_admin])
+    |> cast(attrs, [:active, :is_admin, :nickname])
+    |> cast_attachments(attrs, [:cv])
     |> cast_assoc(:user)
     |> validate_required([:active, :is_admin])
+  end
+
+  def update_changeset_cv(staff, attrs) do
+    staff
+    |> cast_attachments(attrs, [:cv])
   end
 end

--- a/lib/safira/web/uploaders/cv.ex
+++ b/lib/safira/web/uploaders/cv.ex
@@ -47,7 +47,7 @@ defmodule Safira.CV do
   end
 
   def storage_dir(_version, {_file, scope}) do
-    "uploads/attendee/cvs/" <> "#{scope.id}"
+    "uploads/user/cvs/" <> "#{scope.id}"
   end
 
   def s3_object_headers(version, {file, scope}) do

--- a/lib/safira_web/router.ex
+++ b/lib/safira_web/router.ex
@@ -77,6 +77,9 @@ defmodule SafiraWeb.Router do
     resources "/store/buy", BuyController, only: [:create]
     resources "/roulette/prizes", PrizeController, only: [:index, :show]
 
+    get "/staff/cv/:id", CVController, :staff_cv
+    patch "/staff/cv/:id", CVController, :staff_upload_cv
+
     get "/company/attendees/:id", CompanyController, :company_attendees
     get "/company/attendees/cvs/:id", CVController, :company_cvs
   end

--- a/lib/safira_web/views/cv_view.ex
+++ b/lib/safira_web/views/cv_view.ex
@@ -1,0 +1,12 @@
+defmodule SafiraWeb.CVView do
+  use SafiraWeb, :view
+
+  alias Safira.CV
+
+  def render("staff_cv.json", %{staff: staff}) do
+    %{
+      id: staff.id,
+      cv: CV.url({staff.cv, staff}, :original)
+    }
+  end
+end

--- a/priv/repo/migrations/20180724140327_create_staff.exs
+++ b/priv/repo/migrations/20180724140327_create_staff.exs
@@ -5,6 +5,7 @@ defmodule Safira.Repo.Migrations.CreateStaff do
     create table(:staffs) do
       add :active, :boolean, default: true
       add :user_id, references(:users, on_delete: :delete_all)
+      add :nickname, :string
 
       timestamps()
     end

--- a/priv/repo/migrations/20231228221359_add_cv_to_staffs.exs
+++ b/priv/repo/migrations/20231228221359_add_cv_to_staffs.exs
@@ -1,0 +1,9 @@
+defmodule Safira.Repo.Migrations.AddCvToStaffs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:staffs) do
+      add :cv, :string
+    end
+  end
+end


### PR DESCRIPTION
Adds CV upload ability to staffs, also adds a nickname to staffs to create the CV file name (changes seeds and gen scripts to take this into account). Depends on seium.org [#613](https://github.com/cesium/seium.org/pull/613)



 _totally new code that no one has seen before 100% true_