### PR TITLE
feat: make get current spotlight public

### DIFF
--- a/lib/safira_web/controllers/spotlight/spotlight_controller.ex
+++ b/lib/safira_web/controllers/spotlight/spotlight_controller.ex
@@ -25,27 +25,19 @@ defmodule SafiraWeb.SpotlightController do
   end
 
   def current(conn, _params) do
-    is_company = Accounts.is_company(conn)
     spotlight = Interaction.get_spotlight()
 
-    if is_company do
+    if !spotlight || DateTime.compare(spotlight.end, DateTime.utc_now()) == :lt do
       conn
-      |> put_status(:unauthorized)
-      |> json(%{error: "Cannot access resource"})
+      |> put_status(:not_found)
+      |> json(%{error: "Spotlight not found"})
       |> halt()
     else
-      if !spotlight || DateTime.compare(spotlight.end, DateTime.utc_now()) == :lt do
-        conn
-        |> put_status(:not_found)
-        |> json(%{error: "Spotlight not found"})
-        |> halt()
-      else
-        company = Accounts.get_company_by_badge!(spotlight.badge_id)
+      company = Accounts.get_company_by_badge!(spotlight.badge_id)
 
-        conn
-        |> put_status(:ok)
-        |> render(:current, company: company, spotlight: spotlight)
-      end
+      conn
+      |> put_status(:ok)
+      |> render(:current, company: company, spotlight: spotlight)
     end
   end
 

--- a/lib/safira_web/router.ex
+++ b/lib/safira_web/router.ex
@@ -47,6 +47,8 @@ defmodule SafiraWeb.Router do
 
     get "/is_registered/:id", AuthController, :is_registered
 
+    get "/spotlight", SpotlightController, :current
+
     pipe_through :jwt_authenticated
 
     get "/user", AuthController, :user
@@ -62,7 +64,6 @@ defmodule SafiraWeb.Router do
     post "/give_bonus/:id", BonusController, :give_bonus
 
     get "/spotlights", SpotlightController, :index
-    get "/spotlight", SpotlightController, :current
     post "/spotlight/:company_id", SpotlightController, :create
 
     post "/store/redeem", DeliverRedeemableController, :create

--- a/test/safira_web/controllers/spotlight_controller_test.exs
+++ b/test/safira_web/controllers/spotlight_controller_test.exs
@@ -236,65 +236,14 @@ defmodule SafiraWeb.SpotlightControllerTest do
       assert json_response(conn, 404) == %{"error" => "Spotlight not found"}
     end
 
-    test "when user is a staff", %{user: user} do
-      _staff = insert(:staff, user: user, is_admin: false)
-
-      %{conn: conn, user: _user} = api_authenticate(user)
+    test "when the user is not authenticated" do
+      conn = build_conn()
 
       conn =
         conn
         |> get(Routes.spotlight_path(conn, :current))
 
       assert json_response(conn, 404) == %{"error" => "Spotlight not found"}
-    end
-
-    test "when user is an attendee", %{user: user} do
-      _attendee = insert(:attendee, user: user)
-
-      %{conn: conn, user: _user} = api_authenticate(user)
-
-      conn =
-        conn
-        |> get(Routes.spotlight_path(conn, :current))
-
-      assert json_response(conn, 404) == %{"error" => "Spotlight not found"}
-    end
-
-    test "when user is an attendee and a spotlight is running", %{user: user} do
-      _staff = insert(:staff, user: user, is_admin: true)
-      company = insert(:company, remaining_spotlights: 1)
-
-      %{conn: conn, user: _user} = api_authenticate(user)
-
-      # Start a spotlight for the company
-      Interaction.start_spotlight(company)
-      spotlight = Interaction.get_spotlight()
-      assert spotlight != nil
-
-      conn =
-        conn
-        |> get(Routes.spotlight_path(conn, :current))
-
-      assert json_response(conn, 200) == %{
-               "data" => %{
-                 "id" => company.id,
-                 "name" => company.name,
-                 "badge_id" => company.badge_id,
-                 "end" => DateTime.to_iso8601(spotlight.end)
-               }
-             }
-    end
-
-    test "when user is a company", %{user: user} do
-      _company = insert(:company, user: user)
-
-      %{conn: conn, user: _user} = api_authenticate(user)
-
-      conn =
-        conn
-        |> get(Routes.spotlight_path(conn, :current))
-
-      assert json_response(conn, 401) == %{"error" => "Cannot access resource"}
     end
   end
 


### PR DESCRIPTION
Since this endpoint will be used by the frontend server (and not an authenticated client), it needs to be public.