### PR TITLE
fix: unecessary company CVs controller check

### DIFF
--- a/lib/safira_web/controllers/cv_controller.ex
+++ b/lib/safira_web/controllers/cv_controller.ex
@@ -47,7 +47,7 @@ defmodule SafiraWeb.CVController do
 
     company = Accounts.get_company!(company_id)
 
-    if Accounts.is_admin(conn) or (curr_company_id == company.id and company.has_cv_access) do
+    if Accounts.is_admin(conn) or curr_company_id == company.id do
       zip =
         Accounts.list_company_attendees(company_id)
         |> Enum.concat(Accounts.list_staffs())

--- a/test/safira_web/controllers/cv_controller_test.exs
+++ b/test/safira_web/controllers/cv_controller_test.exs
@@ -77,20 +77,6 @@ defmodule SafiraWeb.CVControllerTest do
                (attendee.nickname <> ".pdf") |> String.to_charlist()
     end
 
-    test "company does not have access to CV", %{
-      user_company_no_access: user_company,
-      company_no_access: company,
-      attendee_with_badge: _attendee
-    } do
-      %{conn: conn, user: _user} = api_authenticate(user_company)
-
-      conn =
-        conn
-        |> get(Routes.cv_path(conn, :company_cvs, company.id))
-
-      assert response(conn, 403)
-    end
-
     test "admin downloads the CVs of a company's attendees", %{
       company: company,
       attendee_with_badge: attendee


### PR DESCRIPTION
The controller uses the function `Accounts.list_company_attendees/1` which already validates the sponsor tier of the company and returns the corresponding attendees that should be shown (Exclusive, Gold -> ALL CVs + STAFFS | Silver, Bronze -> ONLY VISITORS + STAFFS). The `has_cv` check was preventing Bronze and Silver sponsors from accessing the endpoint and consequently made them unable to download staff cvs.