### PR TITLE
fix: s3 content types

### DIFF
--- a/lib/safira/uploader.ex
+++ b/lib/safira/uploader.ex
@@ -6,6 +6,10 @@ defmodule Safira.Uploader do
     quote do
       use Waffle.Definition
       use Waffle.Ecto.Definition
+
+      def s3_object_headers(_version, {file, _scope}) do
+        [content_type: MIME.from_path(file.file_name)]
+      end
     end
   end
 end


### PR DESCRIPTION
This was causing SVG files to be uploaded with `application/octet-stream` as the content type, making the images not appear on the HTML.