### PR TITLE
fix: activities not being correctly ordered

### DIFF
--- a/lib/safira_web/live/landing/components/schedule.ex
+++ b/lib/safira_web/live/landing/components/schedule.ex
@@ -369,11 +369,27 @@ defmodule SafiraWeb.Landing.Components.Schedule do
   defp fetch_daily_activities(day, filters) do
     Activities.list_daily_activities(day)
     |> Enum.filter(fn at -> filters == [] or at.category_id in filters end)
-    |> Enum.group_by(& &1.time_start)
-    |> Enum.map(&elem(&1, 1))
+    |> group_activities()
   end
 
   defp fetch_categories do
     Activities.list_activity_categories()
+  end
+
+  defp group_activities(activities) do
+    Enum.reduce(activities, [], fn activity, acc ->
+      case acc do
+        [] ->
+          [[activity]]
+
+        [[head | tail] | rest] = grouped ->
+          if activity.time_start == head.time_start do
+            [[activity, head | tail] | rest]
+          else
+            [[activity] | grouped]
+          end
+      end
+    end)
+    |> Enum.reverse()
   end
 end


### PR DESCRIPTION
The issue is `Enum.group_by/3` does not preserve order. The solution was to create a custom group function ~~that gave me not-so-nice PF flashbacks~~