### PR TITLE
fix: footer links

### DIFF
--- a/lib/safira_web/live/landing/components/footer.ex
+++ b/lib/safira_web/live/landing/components/footer.ex
@@ -41,9 +41,9 @@ defmodule SafiraWeb.Landing.Components.Footer do
       </div>
       <div
         :if={@tip != []}
-        class="hidden lg:flex flex-col items-center w-full justify-center absolute bottom-0 left-0 overflow-clip select-none"
+        class="hidden lg:flex flex-col items-center w-full justify-center absolute bottom-0 left-0 overflow-clip pointer-events-none"
       >
-        <div class="group flex flex-col items-center justify-center">
+        <div class="group flex flex-col items-center justify-center pointer-events-auto">
           <p class="bg-white text-black text-center p-2 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity">
             <%= render_slot(@tip) %>
           </p>


### PR DESCRIPTION
#489 had a bug where the void section was over the links and preventing them to be clicked.