### PR TITLE
chore: make scanner the default staff route

### DIFF
--- a/lib/safira_web/live/landing/components/navbar.ex
+++ b/lib/safira_web/live/landing/components/navbar.ex
@@ -53,7 +53,7 @@ defmodule SafiraWeb.Landing.Components.Navbar do
                       <.dropdown_menu_item
                         :if={user_type?(@current_user, :staff)}
                         link_type="a"
-                        to="/dashboard/attendees"
+                        to="/dashboard/scanner"
                         label="Dashboard"
                       />
                       <.dropdown_menu_item
@@ -116,7 +116,7 @@ defmodule SafiraWeb.Landing.Components.Navbar do
           </div>
           <.link
             :if={user_type?(@current_user, :staff)}
-            patch={~p"/dashboard/attendees"}
+            patch={~p"/dashboard/scanner"}
             phx-click={hide_mobile_navbar()}
             class="font-terminal uppercase text-3xl text-white transition-colors duration-75 ease-in hover:text-accent"
           >

--- a/lib/safira_web/staff_roles.ex
+++ b/lib/safira_web/staff_roles.ex
@@ -26,7 +26,7 @@ defmodule SafiraWeb.StaffRoles do
           {:halt,
            socket
            |> Phoenix.LiveView.put_flash(:error, "You are not authorized to access this page.")
-           |> Phoenix.LiveView.redirect(to: "/dashboard")}
+           |> Phoenix.LiveView.redirect(to: "/dashboard/scanner")}
         end
     end
   end

--- a/lib/safira_web/user_auth.ex
+++ b/lib/safira_web/user_auth.ex
@@ -19,7 +19,7 @@ defmodule SafiraWeb.UserAuth do
   # Redirect paths after login based on user type.
   @redirect_after_login_paths %{
     attendee: "/app/",
-    staff: "/dashboard/attendees",
+    staff: "/dashboard/scanner",
     company: "/sponsor/scanner"
   }
 

--- a/priv/repo/seeds/slots.exs
+++ b/priv/repo/seeds/slots.exs
@@ -9,7 +9,7 @@ defmodule Safira.Repo.Seeds.Slots do
         seed_slots_reel_icons()
 
       _ ->
-        Mix.shell().info("Slots seeds already exist, aborting seeding slots.")
+        Mix.shell().error("Slots seeds already exist, aborting seeding slots.")
     end
   end
 

--- a/priv/repo/seeds/teams.exs
+++ b/priv/repo/seeds/teams.exs
@@ -50,8 +50,7 @@ defmodule Safira.Repo.Seeds.Teams do
 
     case Teams.create_team_member(attrs) do
       {:ok, _member} ->
-        Mix.shell().info("Inserted team member: #{member}")
-
+        nil
       {:error, _changeset} ->
         Mix.shell().error("Failed to insert team member: #{member}")
     end


### PR DESCRIPTION
This was causing problems in production because most staffs don't have access to the attendees page. 
Also, I think it will work better in the event.