### PR TITLE
fix: remove type field from registration changeset

### DIFF
--- a/lib/safira/accounts/user.ex
+++ b/lib/safira/accounts/user.ex
@@ -77,8 +77,8 @@ defmodule Safira.Accounts.User do
   """
   def registration_changeset(user, attrs, opts \\ []) do
     user
-    |> cast(attrs, @required_fields ++ @optional_fields)
-    |> validate_required(@required_fields |> Enum.reject(&(&1 in [:email, :password, :handle])))
+    |> cast(attrs, (@required_fields ++ @optional_fields) -- [:type])
+    |> validate_required(@required_fields |> Enum.reject(&(&1 in [:email, :password, :handle, :type])))
     |> validate_email(opts)
     |> validate_handle()
     |> validate_password(opts)

--- a/lib/safira/accounts/user.ex
+++ b/lib/safira/accounts/user.ex
@@ -78,7 +78,10 @@ defmodule Safira.Accounts.User do
   def registration_changeset(user, attrs, opts \\ []) do
     user
     |> cast(attrs, (@required_fields ++ @optional_fields) -- [:type])
-    |> validate_required(@required_fields |> Enum.reject(&(&1 in [:email, :password, :handle, :type])))
+    |> validate_required(
+      @required_fields
+      |> Enum.reject(&(&1 in [:email, :password, :handle, :type]))
+    )
     |> validate_email(opts)
     |> validate_handle()
     |> validate_password(opts)

--- a/test/safira/accounts_test.exs
+++ b/test/safira/accounts_test.exs
@@ -139,7 +139,7 @@ defmodule Safira.AccountsTest do
   describe "change_user_registration/2" do
     test "returns a changeset" do
       assert %Ecto.Changeset{} = changeset = Accounts.change_user_registration(%User{})
-      assert changeset.required == [:password, :handle, :email, :name, :type]
+      assert changeset.required == [:password, :handle, :email, :name]
     end
 
     test "allows fields to be set" do


### PR DESCRIPTION
Removes the :type field from the registration changeset to ensure all new users are registered as :attendee by default

closes #546 